### PR TITLE
testing-ija_results-inclusion

### DIFF
--- a/home.py
+++ b/home.py
@@ -86,8 +86,6 @@ def filter_dataframe(df: pd.DataFrame) -> pd.DataFrame:
 st.title('Joggling Results Archive')
 st.write("""Joggling (that is, the hybrid sport of running whilst juggling) is certainly a niche. But it is more popular than you might think. 
 This web app aims to present an archive of joggling achievements from around the world.
-
-Please submit joggling results to jogglingresults@gmail.com
 """)
 
 ## Load data and reorder columns
@@ -97,7 +95,7 @@ data = data[['Date', 'Joggler', 'Distance', 'Event / Venue','Finish Time', 'Drop
              'Notes / Result Links', 'Year','Standard Distance?']]
 
 # Summary Stats
-st.write(f"{len(data)} joggling results from {len(data['Joggler'].unique())} jogglers from {len(data['Nationality'].unique())-1} countries discovered so far...")
+st.write(f"{len(data)} joggling results from {len(data['Joggler'].unique())} jogglers from {len(data['Nationality'].unique())-1} countries discovered so far... see all results below.")
 
 st.write(filter_dataframe(data))
 st.write(f'App Updated: {update_date}')

--- a/pages/8-Testing_multitabs.py
+++ b/pages/8-Testing_multitabs.py
@@ -33,34 +33,60 @@ def all_time_list(distance):
 endurance_tab, middle_distance_tab, sprints_tab = st.tabs(['Endurance', 'Middle Distance', 'Sprints'])
 
 with endurance_tab:
-    st.subheader("Endurance Events will sit under this nested tab...")
-    tab1, tab2, tab3, tab4, tab5, tab6, tab7, tab8 = st.tabs(["3b Mile", "3b 5km", "3b 10km",'3b Half Marathon', '3b Marathon', '5b Mile', '5b 5km','5b Marathon'])
-    with tab1:
-        st.subheader("3 Ball Mile")
-        st.write(all_time_list('3b Mile'))
-    with tab2:
+    t_5km_3b, t_10km_3b, t_hmar_3b, t_mar_3b, t_5km_5b, t_mar_5b = st.tabs(["3b 5km", "3b 10km", '3b Half Marathon', '3b Marathon', '5b 5km','5b Marathon'])
+    with t_5km_3b:
         st.subheader("3 Ball 5km")
         st.write(all_time_list('3b 5km'))
-    with tab3:
+    with t_10km_3b:
         st.subheader("3 Ball 10km")
         st.write(all_time_list('3b 10km'))
-    with tab4:
+    with t_hmar_3b:
         st.subheader("3 Ball Half Marathon")
         st.write(all_time_list('3b Half Marathon'))
-    with tab5:
+    with t_mar_3b:
         st.subheader("3 Ball Marathon")
         st.write(all_time_list('3b Marathon'))
-    with tab6:
-        st.subheader("5 Ball Mile")
-        st.write(all_time_list('5b Mile'))
-    with tab7:
+    with t_5km_5b:
         st.subheader("5 Ball 5km")
         st.write(all_time_list('5b 5km'))
-    with tab8:
+    with t_mar_5b:
         st.subheader("5 Ball Marathon")
         st.write(all_time_list('5b Marathon'))
 with middle_distance_tab:
-    st.subheader('Will move the middle distance events here')
+    t_800_3b, t_1500_3b, t_mile_3b, t_mile_5b = st.tabs(["3b 800m", "3b 1500m", "3b Mile", "5b Mile"])
+    with t_800_3b:
+        st.subheader("3 Ball 800m")
+        st.write(all_time_list('3b 800m'))
+    with t_1500_3b:
+        st.subheader("3 Ball 1500m")
+        st.write(all_time_list('3b 1500m'))
+    with t_mile_3b:
+        st.subheader("3 Ball Mile")
+        st.write(all_time_list('3b Mile'))
+    with t_mile_5b:
+        st.subheader("5 Ball Mile")
+        st.write(all_time_list('5b Mile'))
 with sprints_tab:
-    st.subheader('And Sprints (and relays) will live here')
+    t_100_3b,t_100_5b,t_100_7b,t_200_3b,t_400_3b,t_400_5b,t_4x100_3b = st.tabs(["3b 100m", "5b 100m", "7b 100m", "3b 200m", "3b 400m", "5b 400m","3b 4x100m"])
+    with t_100_3b:
+        st.subheader("3 Ball 100m")
+        st.write(all_time_list('3b 100m'))
+    with t_100_5b:
+        st.subheader("5 Ball 100m")
+        st.write(all_time_list('5b 100m'))
+    with t_100_7b:
+        st.subheader("7 Ball 100m")
+        st.write(all_time_list('7b 100m'))
+    with t_200_3b:
+        st.subheader("3 Ball 200m")
+        st.write(all_time_list('3b 200m'))
+    with t_400_3b:
+        st.subheader("3 Ball 400m")
+        st.write(all_time_list('3b 400m'))
+    with t_400_5b:
+        st.subheader("5 Ball 400m")
+        st.write(all_time_list('5b 400m'))
+    with t_4x100_3b:
+        st.subheader("3 Ball 4 x 100m Relay")
+        st.write(all_time_list('3b 4x100m'))
     

--- a/results.csv
+++ b/results.csv
@@ -1,1040 +1,2220 @@
 ﻿Date,Year,Distance,Standard Distance?,Event / Venue,Joggler,Gender,Nationality,Finish Time,Drops,Notes / Result Links
-28/01/2024,2024,3b 6.7km,No,"The Snowy Soles Snowshoe Race, Ontario",Michal Kapral,M,CAN,00:49:24.00,?,https://www.instagram.com/p/C2pmYbarGbq/
-27/01/2024,2024,3b 5km,Yes,Holyrood Parkrun,James McDiarmid,M,GBR,00:21:30.00,0,https://www.parkrun.org.uk/holyrood/results/73/
-27/01/2024,2024,3b 5km,Yes,Młynówka Królewska Parkrun,Kacper Suchora,M,POL,00:23:45.00,?,https://www.parkrun.pl/mlynowkakrolewska/results/18/
-27/01/2024,2024,3b 5km,Yes,Holyrood Parkrun,Scott Jenkins,M,GBR,00:25:21.00,3,https://www.parkrun.org.uk/holyrood/results/73/
-27/01/2024,2024,3b 5km,Yes,College of Micronesia-FSM Fun Run,Dana Lee Ling,M,FSM,00:38:11.00,?,https://www.strava.com/athletes/16093155?oq=dan
-20/01/2024,2024,3b 5km,Yes,Młynówka Królewska Parkrun,Kacper Suchora,M,POL,00:25:06.00,?,https://www.parkrun.pl/mlynowkakrolewska/results/17/
-20/01/2024,2024,3b 5km,Yes,SoJo Break the Freeze 5km,David Tate,M,USA,00:25:37.00,?,
-14/01/2024,2024,3b 5km,Yes,"Shark Bite 5km, Florida",Heather Thompson,F,USA,00:35:22.00,?,https://runsignup.com/Race/Results/24835/IndividualResult/gtCh?resultSetId=433509#U55948253  https://www.instagram.com/p/C2FbTLSOmTN/
-14/01/2024,2023,3b Ultra (28.7m),No,Rasselbock Winter Run,Tim Butler,M,GBR,05:24:17.00,?,https://www.joggling.co.uk/Marathon-List
-13/01/2024,2024,3b 5km,Yes,Młynówka Królewska Parkrun,Kacper Suchora,M,POL,00:24:09.00,?,https://www.parkrun.pl/mlynowkakrolewska/results/16/
-06/01/2024,2024,3b 5km,Yes,Zillmere Parkrun,Narelle Cabassi,F,AUS,00:30:36.00,?,https://www.parkrun.com.au/zillmere/results/253/  https://www.instagram.com/p/C1vlY4tve-F/
-30/12/2023,2023,3b 5km,Yes,Park im. Jana Pawla II Parkrun,Kacper Suchora,M,POL,00:22:10.00,3,https://www.parkrun.pl/parkimjanapawlaii/results/149/
-26/12/2023,2023,3b 5km,Yes,Ogrod Saski Parkrun,Kacper Suchora,M,POL,00:23:13.00,3,https://www.parkrun.pl/ogrodsaski/results/160/
-23/12/2023,2023,3b 5km,Yes,Park im. Jana Pawla II Parkrun,Kacper Suchora,M,POL,00:22:59.00,?,https://www.parkrun.pl/parkimjanapawlaii/results/148/ Finished 2nd overall
-23/12/2023,2023,3b 5km,Yes,"Watergrove Parkrun, Rochdale",Jake Lodge,M,GBR,00:24:00.00,5,https://www.strava.com/activities/10423529584
-23/12/2023,2023,3c 5km,Yes,Ogrod Saski Parkrun,Piotr Maciejewski,M,POL,00:28:29.00,?,https://www.parkrun.pl/ogrodsaski/results/159/  https://www.instagram.com/p/C1PZlfZNxZU/
-17/12/2023,2023,3b 5km,Yes,Edinburgh Parkrun,James McDiarmid,M,GBR,00:20:01.00,0,https://www.instagram.com/p/C09KG53t49D/
-17/12/2023,2023,3b Marathon,Yes,Portsmouth Coastal Marathon,Tim Butler,M,GBR,04:43:28.00,?,https://www.joggling.co.uk/Marathon-List    https://www.strava.com/activities/10395071435
-16/12/2023,2023,3b 5km,Yes,"Santa Run 5km, Madison, Wisconsin",Samuel Dean,M,USA,00:19:21.00,1,https://www.strava.com/activities/10391427729
-16/12/2023,2023,3b 5km,Yes,Gunnersbury Parkrun,Jake Lodge,M,GBR,00:20:18.00,0,https://www.parkrun.org.uk/gunnersbury/results/551/   https://www.strava.com/activities/10387513928
-16/12/2023,2023,3b 5km,Yes,Saski Garden Parkrun,Piotr Maciejewski,M,POL,00:24:17.00,?,https://www.parkrun.pl/ogrodsaski/results/158/   https://www.instagram.com/p/C085THksMId/
-15/12/2023,2023,3b 5km,Yes,Mlynowka Krolewska Parkrun,Kacper Suchora,M,POL,00:24:54.00,?,https://www.parkrun.pl/mlynowkakrolewska/results/12/
-10/12/2023,2023,3b Marathon,Yes,Christmas Canal Canter,Tim Butler,M,GBR,04:47:04.00,?,https://www.joggling.co.uk/Marathon-List   https://www.strava.com/activities/10359040637
-10/12/2023,2023,5b Marathon,Yes,Dallas Marathon,Barry Goldmeier,M,USA,06:28:04.00,?,https://mychiptime.com/searchevent.php?id=15519
-09/12/2023,2023,3b 5km,Yes,Livingston Parkrun,Scott Jenkins,M,GBR,00:26:46.00,1,https://www.parkrun.org.uk/livingston/results/341/  https://www.strava.com/activities/10351755810
-03/12/2023,2023,3c 3km,No,Blackpool Santa Dash,JL Coldham,M,GBR,00:22:43.00,?,https://www.strava.com/activities/10321484421
-02/12/2023,2023,3b 5km,Yes,"Frosty 5km, Middletown, Pittsburgh",Tim Ebersole,M,USA,00:21:00.00,?,https://www.strava.com/activities/10316799917
-02/12/2023,2023,3b 5km,Yes,Meadowmill Parkrun,Scott Jenkins,M,GBR,00:22:45.00,0,https://www.parkrun.org.uk/meadowmill/results/159/  https://www.strava.com/activities/10315030947
-02/12/2023,2023,3b 5km,Yes,Robelle Domain Parkrun,Narelle Cabassi,F,AUS,00:29:15.00,?,https://www.instagram.com/p/C0VFX0GPdy6/?img_index=1 https://www.parkrun.com.au/robelledomain/results/62
-30/11/2023,2023,3b 5km,Yes,I Ty Możesz Biegać Wieczorem,Kacper Suchora,M,POL,00:24:17.00,?,https://itmbw.pl/itmbwieczorem-wyniki?id=574
-26/11/2023,2023,3b 10km,Yes,Nowa Huta w Czterech Smakach - Jesien,Kacper Suchora,M,POL,00:52:35.00,?,https://utm.run/wp-content/uploads/2023/11/2023_nh4s_jesien_10.pdf
-26/11/2023,2023,3b 12km,No,"Navisink Challenge, New Jersey",Karly Swaim,F,USA,01:15:23.00,1,
-26/11/2023,2023,3b Half Marathon,Yes,Edinburgh Mo Run,James McDiarmid,M,GBR,01:39:56.00,0,
-25/11/2023,2023,3b 5km,Yes,Meadowmill Parkrun,Scott Jenkins,M,GBR,00:21:00.00,0,https://www.strava.com/activities/10277539916
-24/11/2023,2023,3b 5 Mile,No,"Born to Run 5 Mile Race, New Jersey",Karly Swaim,F,USA,00:47:42.00,0,
-23/11/2023,2023,3b 5 Mile,No,Turkey Trot - FDL,Samuel Dean,M,USA,00:31:20.00,0,https://www.strava.com/activities/10268547704
-23/11/2023,2023,3b 5 Mile,No,"Turkey Tory - Lifetime, Chicago",Perry Romanowski,M,USA,00:40:51.00,?,
-23/11/2023,2023,3b 10km,Yes,"Turkey Trot - Newport, PA",Tim Ebersole,M,USA,00:44:44.00,?,
-23/11/2023,2023,3b 5 Mile,No,Turkey Trot - Thundercloud,Kalia Handy Bosma,F,USA,01:23:04.00,?,
-23/11/2023,2023,3c 5 Mile,No,Turkey Trot - Thundercloud,John Handy Bosma,M,USA,01:23:05.00,?,
-19/11/2023,2023,3b 10km,Yes,"Fat Ass Trail Race, Ontario",Michal Kapral,M,CAN,00:56:46.00,6,
-19/11/2023,2023,5b 10km,Yes,Time Trial,Stefan Nygard,M,SWE,01:05:41.00,?,https://www.strava.com/activities/10246053281
-18/11/2023,2023,3b 5km,Yes,Edinburgh Parkrun,James McDiarmid,M,GBR,00:19:20.00,0,https://www.parkrun.org.uk/edinburgh/results/651/
-18/11/2023,2023,3b 5km,Yes,Parkrun Mylnowka Krolewska,Kacper Suchora,M,POL,00:25:01.00,?,https://www.parkrun.pl/mlynowkakrolewska/results/8
-18/11/2023,2023,3b 5km,Yes,Robelle Domain Parkrun,Narelle Cabassi,F,AUS,00:30:07.00,?,https://www.instagram.com/p/CzxZJMDvJpI/  https://www.parkrun.com.au/robelledomain/results/60
-12/11/2023,2023,3b Marathon,Yes,Madison Marathon,Samuel Dean,M,USA,03:42:39.00,14,https://www.strava.com/activities/10207532452
-12/11/2023,2023,3b Marathon,Yes,Pierrepoint Plod,Tim Butler,M,GBR,04:38:02.00,?,https://www.joggling.co.uk/Marathon-List
-11/11/2023,2023,3b 5km,Yes,Edinburgh Parkrun,James McDiarmid,M,GBR,00:19:30.00,3,https://www.parkrun.org.uk/edinburgh/results/650/
-11/11/2023,2023,3b 5km,Yes,Cliffe Castle Parkrun,Jake Lodge,M,GBR,00:22:39.00,?,https://www.strava.com/activities/10197880347  https://www.parkrun.org.uk/cliffecastle/results/198/
-11/11/2023,2023,3b 5km,Yes,Whitekirk Hill Parkrun,Scott Jenkins,M,GBR,00:24:10.00,1,https://www.strava.com/activities/10201641671
-11/11/2023,2023,3b 5km,Yes,Parkrun Mylnowka Krolewska,Kacper Suchora,M,POL,00:25:49.00,?,https://www.parkrun.pl/mlynowkakrolewska/results/7
-11/11/2023,2023,3b Half Marathon,Yes,"Richmond Half Marathon, VA",Jonathan Austin,M,USA,01:51:26.00,?,https://runsignup.com/Race/Results/53399/IndividualResult/bfNJ?resultSetId=425038#U82282467
-11/11/2023,2023,5b Marathon,Yes,"Richmon Marathon, VA",Barry Goldmeier,M,USA,06:58:01.00,?,
-06/11/2023,2023,3b 15km,No,Istanbul Marathon,Levent Denizci,M,TUR,01:23:07.00,1,https://www.instagram.com/reel/CzSprRmIVAO/
-05/11/2023,2023,3b Marathon,Yes,New York City Marathon,Jack Hirschowitz,M,USA,05:10:39.00,?,
-05/11/2023,2023,5b Marathon,Yes,New York City Marathon,Barry Goldmeier,M,USA,06:54:28.00,?,
-04/11/2023,2023,3b 5km,Yes,Brighton & Hove Parkrun,Scott Jenkins,M,GBR,00:23:53.00,0,https://www.strava.com/activities/10162658912
-04/11/2023,2023,3b 5km,Yes,Tremorfa Parkrun,Derrick Adams,M,GBR,00:27:49.00,?,https://www.parkrun.org.uk/tremorfa/news/2023/11/04/the-one-with-the-juggler/   https://www.facebook.com/reel/1117103175936729   https://www.parkrun.org.uk/tremorfa/results/125/
-29/10/2023,2023,3b 4 Mile,No,JSRC Deal Trick or Trot,Karly Swaim,F,USA,00:38:06.00,?,With lemons!
-28/10/2023,2023,3b 5km,Yes,Holyrood Parkrun,James McDiarmid,M,GBR,00:20:30.00,2,https://www.parkrun.org.uk/holyrood/results/62/
-28/10/2023,2023,3b 5km,Yes,Holyrood Parkrun,Scott Jenkins,M,GBR,00:25:21.00,0,https://www.parkrun.org.uk/holyrood/results/62/
-22/10/2023,2023,3b 10km,Yes,Mens 10km Edinburgh,James McDiarmid,M,GBR,00:39:57.00,0,https://www.myrunning.uk/mens-10k-edinburgh/results-stats?entry_id=1433665&race_number=10355&people_id=701492
-22/10/2023,2023,3b Marathon,Yes,Abingdon Marathon,Scott Jenkins,M,GBR,04:23:12.00,1,https://www.strava.com/activities/10084587222
-22/10/2023,2023,3b Marathon,Yes,Monster Mash Marathon,Tim Butler,M,GBR,04:39:22.00,?,https://www.strava.com/activities/10084951644
-21/10/2023,2023,3b 5km,Yes,Morecambe Prom Parkrun,Nick Burns,M,GBR,00:34:11.00,?,https://www.parkrun.org.uk/morecambeprom/results/163
-16/10/2023,2023,3b 10km,Yes,Bospho Run,Levent Denizci,M,TUR,00:52:10.00,?,https://www.instagram.com/reel/Cyc1DdXADLa/
-15/10/2023,2023,5b 5km,Yes,Time Trial,Stefan Nygard,M,SWE,00:32:50.00,?,https://www.strava.com/activities/10040574029
-15/10/2023,2023,3b Marathon,Yes,Toronto Waterfront Marathon,Michael-Lucien Bergeron,M,CAN,03:00:06.00,?,https://www.strava.com/activities/10044512008
-15/10/2023,2023,3b Marathon,Yes,Yorkshire Marathon,Chris Edwin,M,GBR,03:00:06.00,1,https://www.strava.com/activities/10042614562/
-08/10/2023,2023,3b Half Marathon,Yes,Burnham Half Marathon,Scott Jenkins,M,GBR,01:56:36.00,0,https://www.facebook.com/photo?fbid=170412179447395&set=pcb.170412272780719 https://www.strava.com/activities/9999632050 https://www.burnham-on-sea.com/news/burnham-on-sea-half-marathon-2023-photos-full-results-and-video/ https://www.burnham-on-sea.com/news/video-runner-juggles-for-two-hours-while-running-burnham-on-sea-half-marathon/
-08/10/2023,2023,3b Marathon,Yes,Chicago Marathon,Barry Goldmeier,M,USA,06:25:32.00,?,https://uk.news.yahoo.com/joggler-completes-chicago-marathon-while-224404208.html?guccounter=1
-07/10/2023,2023,3b 5km,Yes,Roberts Park Parkrun,Jake Lodge,M,GBR,00:20:37.00,3,https://www.strava.com/activities/9993036091  https://www.parkrun.org.uk/robertspark/results/100/
-07/10/2023,2023,3b 5km,Yes,Burnham and Highbridge Parkrun,Scott Jenkins,M,GBR,00:29:02.00,1,"https://www.strava.com/activities/9991966505
+28/01/2024,2024,3b 6.7km,No,"The Snowy Soles Snowshoe Race, Ontario",Michal Kapral,M,CAN,49:24.0,?,https://www.instagram.com/p/C2pmYbarGbq/
+27/01/2024,2024,3b 5km,Yes,Holyrood Parkrun,James McDiarmid,M,GBR,21:30.0,0,https://www.parkrun.org.uk/holyrood/results/73/
+27/01/2024,2024,3b 5km,Yes,Młynówka Królewska Parkrun,Kacper Suchora,M,POL,23:45.0,?,https://www.parkrun.pl/mlynowkakrolewska/results/18/
+27/01/2024,2024,3b 5km,Yes,Holyrood Parkrun,Scott Jenkins,M,GBR,25:21.0,3,https://www.parkrun.org.uk/holyrood/results/73/
+27/01/2024,2024,3b 5km,Yes,College of Micronesia-FSM Fun Run,Dana Lee Ling,M,FSM,38:11.0,?,https://www.strava.com/athletes/16093155?oq=dan
+20/01/2024,2024,3b 5km,Yes,Młynówka Królewska Parkrun,Kacper Suchora,M,POL,25:06.0,?,https://www.parkrun.pl/mlynowkakrolewska/results/17/
+20/01/2024,2024,3b 5km,Yes,SoJo Break the Freeze 5km,David Tate,M,USA,25:37.0,?,
+14/01/2024,2024,3b 5km,Yes,"Shark Bite 5km, Florida",Heather Thompson,F,USA,35:22.0,?,https://runsignup.com/Race/Results/24835/IndividualResult/gtCh?resultSetId=433509#U55948253  https://www.instagram.com/p/C2FbTLSOmTN/
+14/01/2024,2023,3b Ultra (28.7m),No,Rasselbock Winter Run,Tim Butler,M,GBR,24:17.0,?,https://www.joggling.co.uk/Marathon-List
+13/01/2024,2024,3b 5km,Yes,Młynówka Królewska Parkrun,Kacper Suchora,M,POL,24:09.0,?,https://www.parkrun.pl/mlynowkakrolewska/results/16/
+06/01/2024,2024,3b 5km,Yes,Zillmere Parkrun,Narelle Cabassi,F,AUS,30:36.0,?,https://www.parkrun.com.au/zillmere/results/253/  https://www.instagram.com/p/C1vlY4tve-F/
+30/12/2023,2023,3b 5km,Yes,Park im. Jana Pawla II Parkrun,Kacper Suchora,M,POL,22:10.0,3,https://www.parkrun.pl/parkimjanapawlaii/results/149/
+26/12/2023,2023,3b 5km,Yes,Ogrod Saski Parkrun,Kacper Suchora,M,POL,23:13.0,3,https://www.parkrun.pl/ogrodsaski/results/160/
+23/12/2023,2023,3b 5km,Yes,Park im. Jana Pawla II Parkrun,Kacper Suchora,M,POL,22:59.0,?,https://www.parkrun.pl/parkimjanapawlaii/results/148/ Finished 2nd overall
+23/12/2023,2023,3b 5km,Yes,"Watergrove Parkrun, Rochdale",Jake Lodge,M,GBR,24:00.0,5,https://www.strava.com/activities/10423529584
+23/12/2023,2023,3c 5km,Yes,Ogrod Saski Parkrun,Piotr Maciejewski,M,POL,28:29.0,?,https://www.parkrun.pl/ogrodsaski/results/159/  https://www.instagram.com/p/C1PZlfZNxZU/
+17/12/2023,2023,3b 5km,Yes,Edinburgh Parkrun,James McDiarmid,M,GBR,20:01.0,0,https://www.instagram.com/p/C09KG53t49D/
+17/12/2023,2023,3b Marathon,Yes,Portsmouth Coastal Marathon,Tim Butler,M,GBR,43:28.0,?,https://www.joggling.co.uk/Marathon-List    https://www.strava.com/activities/10395071435
+16/12/2023,2023,3b 5km,Yes,"Santa Run 5km, Madison, Wisconsin",Samuel Dean,M,USA,19:21.0,1,https://www.strava.com/activities/10391427729
+16/12/2023,2023,3b 5km,Yes,Gunnersbury Parkrun,Jake Lodge,M,GBR,20:18.0,0,https://www.parkrun.org.uk/gunnersbury/results/551/   https://www.strava.com/activities/10387513928
+16/12/2023,2023,3b 5km,Yes,Saski Garden Parkrun,Piotr Maciejewski,M,POL,24:17.0,?,https://www.parkrun.pl/ogrodsaski/results/158/   https://www.instagram.com/p/C085THksMId/
+15/12/2023,2023,3b 5km,Yes,Mlynowka Krolewska Parkrun,Kacper Suchora,M,POL,24:54.0,?,https://www.parkrun.pl/mlynowkakrolewska/results/12/
+10/12/2023,2023,3b Marathon,Yes,Christmas Canal Canter,Tim Butler,M,GBR,47:04.0,?,https://www.joggling.co.uk/Marathon-List   https://www.strava.com/activities/10359040637
+10/12/2023,2023,5b Marathon,Yes,Dallas Marathon,Barry Goldmeier,M,USA,28:04.0,?,https://mychiptime.com/searchevent.php?id=15519
+09/12/2023,2023,3b 5km,Yes,Livingston Parkrun,Scott Jenkins,M,GBR,26:46.0,1,https://www.parkrun.org.uk/livingston/results/341/  https://www.strava.com/activities/10351755810
+03/12/2023,2023,3c 3km,No,Blackpool Santa Dash,JL Coldham,M,GBR,22:43.0,?,https://www.strava.com/activities/10321484421
+02/12/2023,2023,3b 5km,Yes,"Frosty 5km, Middletown, Pittsburgh",Tim Ebersole,M,USA,21:00.0,?,https://www.strava.com/activities/10316799917
+02/12/2023,2023,3b 5km,Yes,Meadowmill Parkrun,Scott Jenkins,M,GBR,22:45.0,0,https://www.parkrun.org.uk/meadowmill/results/159/  https://www.strava.com/activities/10315030947
+02/12/2023,2023,3b 5km,Yes,Robelle Domain Parkrun,Narelle Cabassi,F,AUS,29:15.0,?,https://www.instagram.com/p/C0VFX0GPdy6/?img_index=1 https://www.parkrun.com.au/robelledomain/results/62
+30/11/2023,2023,3b 5km,Yes,I Ty Możesz Biegać Wieczorem,Kacper Suchora,M,POL,24:17.0,?,https://itmbw.pl/itmbwieczorem-wyniki?id=574
+26/11/2023,2023,3b 10km,Yes,Nowa Huta w Czterech Smakach - Jesien,Kacper Suchora,M,POL,52:35.0,?,https://utm.run/wp-content/uploads/2023/11/2023_nh4s_jesien_10.pdf
+26/11/2023,2023,3b 12km,No,"Navisink Challenge, New Jersey",Karly Swaim,F,USA,15:23.0,1,
+26/11/2023,2023,3b Half Marathon,Yes,Edinburgh Mo Run,James McDiarmid,M,GBR,39:56.0,0,
+25/11/2023,2023,3b 5km,Yes,Meadowmill Parkrun,Scott Jenkins,M,GBR,21:00.0,0,https://www.strava.com/activities/10277539916
+24/11/2023,2023,3b 5 Mile,No,"Born to Run 5 Mile Race, New Jersey",Karly Swaim,F,USA,47:42.0,0,
+23/11/2023,2023,3b 5 Mile,No,Turkey Trot - FDL,Samuel Dean,M,USA,31:20.0,0,https://www.strava.com/activities/10268547704
+23/11/2023,2023,3b 5 Mile,No,"Turkey Tory - Lifetime, Chicago",Perry Romanowski,M,USA,40:51.0,?,
+23/11/2023,2023,3b 10km,Yes,"Turkey Trot - Newport, PA",Tim Ebersole,M,USA,44:44.0,?,
+23/11/2023,2023,3b 5 Mile,No,Turkey Trot - Thundercloud,Kalia Handy Bosma,F,USA,23:04.0,?,
+23/11/2023,2023,3c 5 Mile,No,Turkey Trot - Thundercloud,John Handy Bosma,M,USA,23:05.0,?,
+19/11/2023,2023,3b 10km,Yes,"Fat Ass Trail Race, Ontario",Michal Kapral,M,CAN,56:46.0,6,
+19/11/2023,2023,5b 10km,Yes,Time Trial,Stefan Nygard,M,SWE,05:41.0,?,https://www.strava.com/activities/10246053281
+18/11/2023,2023,3b 5km,Yes,Edinburgh Parkrun,James McDiarmid,M,GBR,19:20.0,0,https://www.parkrun.org.uk/edinburgh/results/651/
+18/11/2023,2023,3b 5km,Yes,Parkrun Mylnowka Krolewska,Kacper Suchora,M,POL,25:01.0,?,https://www.parkrun.pl/mlynowkakrolewska/results/8
+18/11/2023,2023,3b 5km,Yes,Robelle Domain Parkrun,Narelle Cabassi,F,AUS,30:07.0,?,https://www.instagram.com/p/CzxZJMDvJpI/  https://www.parkrun.com.au/robelledomain/results/60
+12/11/2023,2023,3b Marathon,Yes,Madison Marathon,Samuel Dean,M,USA,42:39.0,14,https://www.strava.com/activities/10207532452
+12/11/2023,2023,3b Marathon,Yes,Pierrepoint Plod,Tim Butler,M,GBR,38:02.0,?,https://www.joggling.co.uk/Marathon-List
+11/11/2023,2023,3b 5km,Yes,Edinburgh Parkrun,James McDiarmid,M,GBR,19:30.0,3,https://www.parkrun.org.uk/edinburgh/results/650/
+11/11/2023,2023,3b 5km,Yes,Cliffe Castle Parkrun,Jake Lodge,M,GBR,22:39.0,?,https://www.strava.com/activities/10197880347  https://www.parkrun.org.uk/cliffecastle/results/198/
+11/11/2023,2023,3b 5km,Yes,Whitekirk Hill Parkrun,Scott Jenkins,M,GBR,24:10.0,1,https://www.strava.com/activities/10201641671
+11/11/2023,2023,3b 5km,Yes,Parkrun Mylnowka Krolewska,Kacper Suchora,M,POL,25:49.0,?,https://www.parkrun.pl/mlynowkakrolewska/results/7
+11/11/2023,2023,3b Half Marathon,Yes,"Richmond Half Marathon, VA",Jonathan Austin,M,USA,51:26.0,?,https://runsignup.com/Race/Results/53399/IndividualResult/bfNJ?resultSetId=425038#U82282467
+11/11/2023,2023,5b Marathon,Yes,"Richmon Marathon, VA",Barry Goldmeier,M,USA,58:01.0,?,
+06/11/2023,2023,3b 15km,No,Istanbul Marathon,Levent Denizci,M,TUR,23:07.0,1,https://www.instagram.com/reel/CzSprRmIVAO/
+05/11/2023,2023,3b Marathon,Yes,New York City Marathon,Jack Hirschowitz,M,USA,10:39.0,?,
+05/11/2023,2023,5b Marathon,Yes,New York City Marathon,Barry Goldmeier,M,USA,54:28.0,?,
+04/11/2023,2023,3b 5km,Yes,Brighton & Hove Parkrun,Scott Jenkins,M,GBR,23:53.0,0,https://www.strava.com/activities/10162658912
+04/11/2023,2023,3b 5km,Yes,Tremorfa Parkrun,Derrick Adams,M,GBR,27:49.0,?,https://www.parkrun.org.uk/tremorfa/news/2023/11/04/the-one-with-the-juggler/   https://www.facebook.com/reel/1117103175936729   https://www.parkrun.org.uk/tremorfa/results/125/
+29/10/2023,2023,3b 4 Mile,No,JSRC Deal Trick or Trot,Karly Swaim,F,USA,38:06.0,?,With lemons!
+28/10/2023,2023,3b 5km,Yes,Holyrood Parkrun,James McDiarmid,M,GBR,20:30.0,2,https://www.parkrun.org.uk/holyrood/results/62/
+28/10/2023,2023,3b 5km,Yes,Holyrood Parkrun,Scott Jenkins,M,GBR,25:21.0,0,https://www.parkrun.org.uk/holyrood/results/62/
+22/10/2023,2023,3b 10km,Yes,Mens 10km Edinburgh,James McDiarmid,M,GBR,39:57.0,0,https://www.myrunning.uk/mens-10k-edinburgh/results-stats?entry_id=1433665&race_number=10355&people_id=701492
+22/10/2023,2023,3b Marathon,Yes,Abingdon Marathon,Scott Jenkins,M,GBR,23:12.0,1,https://www.strava.com/activities/10084587222
+22/10/2023,2023,3b Marathon,Yes,Monster Mash Marathon,Tim Butler,M,GBR,39:22.0,?,https://www.strava.com/activities/10084951644
+21/10/2023,2023,3b 5km,Yes,Morecambe Prom Parkrun,Nick Burns,M,GBR,34:11.0,?,https://www.parkrun.org.uk/morecambeprom/results/163
+16/10/2023,2023,3b 10km,Yes,Bospho Run,Levent Denizci,M,TUR,52:10.0,?,https://www.instagram.com/reel/Cyc1DdXADLa/
+15/10/2023,2023,5b 5km,Yes,Time Trial,Stefan Nygard,M,SWE,32:50.0,?,https://www.strava.com/activities/10040574029
+15/10/2023,2023,3b Marathon,Yes,Toronto Waterfront Marathon,Michael-Lucien Bergeron,M,CAN,00:06.0,?,https://www.strava.com/activities/10044512008
+15/10/2023,2023,3b Marathon,Yes,Yorkshire Marathon,Chris Edwin,M,GBR,00:06.0,1,https://www.strava.com/activities/10042614562/
+08/10/2023,2023,3b Half Marathon,Yes,Burnham Half Marathon,Scott Jenkins,M,GBR,56:36.0,0,https://www.facebook.com/photo?fbid=170412179447395&set=pcb.170412272780719 https://www.strava.com/activities/9999632050 https://www.burnham-on-sea.com/news/burnham-on-sea-half-marathon-2023-photos-full-results-and-video/ https://www.burnham-on-sea.com/news/video-runner-juggles-for-two-hours-while-running-burnham-on-sea-half-marathon/
+08/10/2023,2023,3b Marathon,Yes,Chicago Marathon,Barry Goldmeier,M,USA,25:32.0,?,https://uk.news.yahoo.com/joggler-completes-chicago-marathon-while-224404208.html?guccounter=1
+07/10/2023,2023,3b 5km,Yes,Roberts Park Parkrun,Jake Lodge,M,GBR,20:37.0,3,https://www.strava.com/activities/9993036091  https://www.parkrun.org.uk/robertspark/results/100/
+07/10/2023,2023,3b 5km,Yes,Burnham and Highbridge Parkrun,Scott Jenkins,M,GBR,29:02.0,1,"https://www.strava.com/activities/9991966505
 https://www.parkrun.org.uk/burnhamandhighbridge/results/359/"
-05/10/2023,2023,3b 5km,Yes,I Ty Możesz Biegać Wieczorem #563,Kacper Suchora,M,POL,00:31:36.00,?,https://itmbw.pl/itmbwieczorem-wyniki?id=563
-03/10/2023,2023,3b 5km,Yes,Volksgarten Parkrun,Scott Jenkins,M,GBR,00:20:48.00,0,"https://www.strava.com/activities/9967168716 https://www.facebook.com/reel/1350475955583730
+05/10/2023,2023,3b 5km,Yes,I Ty Możesz Biegać Wieczorem #563,Kacper Suchora,M,POL,31:36.0,?,https://itmbw.pl/itmbwieczorem-wyniki?id=563
+03/10/2023,2023,3b 5km,Yes,Volksgarten Parkrun,Scott Jenkins,M,GBR,20:48.0,0,"https://www.strava.com/activities/9967168716 https://www.facebook.com/reel/1350475955583730
 https://www.parkrun.com.de/volksgarten/results/146/"
-01/10/2023,2023,3b Mile,Yes,Time Trial,Chris Edwin,M,GBR,00:05:29.00,?,https://www.strava.com/activities/9956880609
-01/10/2023,2023,3b 5km,Yes,Time Trial,Chris Edwin,M,GBR,00:18:21.00,?,https://www.strava.com/activities/9956880609
-01/10/2023,2023,3b Marathon,Yes,Loch Ness Marathon,James McDiarmid,M,GBR,03:35:25.00,15,https://sportmaniacs.com/en/races/loch-ness-marathon-and-festival-of-running-2023/6519b142-5b68-4e22-930c-4560ac1f1ad9/results/athlete/2267/results
-30/09/2023,2023,3b 5km,Yes,Torvean Parkrun,James McDiarmid,M,GBR,00:19:57.00,?,https://www.facebook.com/torveanparkrun/videos/695705485378377  https://www.parkrun.org.uk/torvean/results/105/
-30/09/2023,2023,3b 5km,Yes,Plean Parkrun,Scott Jenkins,M,GBR,00:24:40.00,1,https://www.parkrun.org.uk/plean/results/223/  https://www.strava.com/activities/9947669351  https://www.parkrun.org.uk/plean/news/2023/09/30/juggling-milestones/
-24/09/2023,2023,3b 10km,Yes,Chester Zoo,EJ Coldham,F,GBR,00:58:23.00,?,https://www.strava.com/activities/9909298131
-24/09/2023,2023,3c 10km,Yes,Chester Zoo,JL Coldham,M,GBR,01:07:07.00,?,https://www.strava.com/activities/9909388387
-24/09/2023,2023,3b Half Marathon,Yes,Badger Challenge,Samuel Dean,M,USA,01:28:08.00,4,https://www.strava.com/activities/9912752839
-24/09/2023,2023,3b Half Marathon,Yes,Scottish Half Marathon,James McDiarmid,M,GBR,01:33:28.00,0,https://www.scottishhalfmarathon.com/results
-24/09/2023,2023,3b Marathon,Yes,Bedford Aerodrome,Tim Butler,M,GBR,04:07:53.00,?,https://results.runthrough.co.uk/myresults.aspx?uid=16487-4971-6-3584757
-23/09/2023,2023,3b 5km,Yes,Penallta Parkrun,Scott Jenkins,M,GBR,00:22:38.00,2,https://www.parkrun.org.uk/penallta/results/346/
-17/09/2023,2023,3b 10km,Yes,Tübingen Heritage Run,Peter Rottenbach,M,DEU,01:01:15.00,?,https://my.raceresult.com/248587/#0_128718 
-16/09/2023,2023,3b 5km,Yes,Holyrood Parkrun,James McDiarmid,M,GBR,00:19:53.00,?,https://www.parkrun.org.uk/holyrood/results/56/
-16/09/2023,2023,3b 5km,Yes,Coed Cefn-pwll-du Parkrun,Scott Jenkins,M,GBR,00:23:59.00,0,https://www.facebook.com/100070150012167/videos/3833914350163308  https://www.parkrun.org.uk/coedcefnpwlldu/results/103/
-10/09/2023,2023,3b Half Marathon,Yes,Harrisburg Half Marathon,Tim Ebersole,M,USA,01:42:57.00,?,https://www.strava.com/activities/9821889643  https://runsignup.com/Race/Results/15430
-09/09/2023,2023,3b 5km,Yes,Holyrood Parkrun,James McDiarmid,M,GBR,00:20:01.00,0,https://www.parkrun.org.uk/holyrood/results/55/
-09/09/2023,2023,4b 5km,No,Zuiderpark Parkrun,Scott Jenkins,M,GBR,00:37:32.00,50,https://www.facebook.com/reel/326772983079041  https://www.parkrun.co.nl/zuiderpark/results/95/  https://twitter.com/OonaghLewis/status/1700803926184911241?t=9Nu6QfJj-yCyN6Y2r3IbIA&s=19&fbclid=IwAR3C7MyJ8eWmpR_NLBeN_CmoOCdB-3nm4o3TKAWOvw4zOLdlvzax6GFUanU
-02/09/2023,2023,3b 5km,Yes,Holyrood Parkrun,James McDiarmid,M,GBR,00:19:39.00,0,https://www.parkrun.org.uk/holyrood/results/54/
-26/08/2023,2023,3b 5km,Yes,Holyrood Parkrun,James McDiarmid,M,GBR,00:19:43.00,?,https://twitter.com/BobakChampion/status/1695403676653764661?t=V1talFM3LhClas5Hx3vH-w&s=19
-26/08/2023,2023,3b 5km,Yes,Roberts Park Parkrun,Jake Lodge,M,GBR,00:20:11.00,2,https://www.parkrun.org.uk/robertspark/results/95/  https://www.strava.com/activities/9722525613
-26/08/2023,2023,3b 5km,Yes,Vogrie Parkrun,Scott Jenkins,M,GBR,00:23:09.00,0,https://www.strava.com/activities/9722797495  https://www.parkrun.org.uk/vogrie/results/245/
-26/08/2023,2023,3c 5km,Yes,Jersey Shore Womens 5km,Karly Swaim,F,USA,00:34:29.00,?,https://runsignup.com/Race/Results/21839#resultSetId-400750;perpage:100  https://www.facebook.com/photo/?fbid=10108409452955774&set=g.372157942956062
-22/08/2023,2023,3b 10km,Yes,Time Trial,David Tate,M,USA,00:59:43.00,?,https://twitter.com/dren_braves/status/1693825675399168506/photo/1
-19/08/2023,2023,3b 5km,Yes,Torvean Parkrun,James McDiarmid,M,GBR,00:20:19.00,0,https://www.parkrun.org.uk/torvean/results/99/?utm_medium=email&utm_source=resultsemail&utm_campaign=systememail
-19/08/2023,2023,3b 5km,Yes,Huddersfield Parkrun,Jake Lodge,M,GBR,00:21:58.00,2,https://www.strava.com/activities/9677079696 https://www.parkrun.org.uk/huddersfield/results/547/
-19/08/2023,2023,3b 5km,Yes,Ogrod Saski Parkrun,Kacper Suchora,M,POL,00:33:36.00,?,https://www.parkrun.pl/ogrodsaski/results/143/
-19/08/2023,2023,4b 5km,No,Perth Parkrun,Scott Jenkins,M,GBR,00:37:39.00,40,"https://www.parkrun.org.uk/perth/results/438/
+01/10/2023,2023,3b Mile,Yes,Time Trial,Chris Edwin,M,GBR,05:29.0,?,https://www.strava.com/activities/9956880609
+01/10/2023,2023,3b 5km,Yes,Time Trial,Chris Edwin,M,GBR,18:21.0,?,https://www.strava.com/activities/9956880609
+01/10/2023,2023,3b Marathon,Yes,Loch Ness Marathon,James McDiarmid,M,GBR,35:25.0,15,https://sportmaniacs.com/en/races/loch-ness-marathon-and-festival-of-running-2023/6519b142-5b68-4e22-930c-4560ac1f1ad9/results/athlete/2267/results
+30/09/2023,2023,3b 5km,Yes,Torvean Parkrun,James McDiarmid,M,GBR,19:57.0,?,https://www.facebook.com/torveanparkrun/videos/695705485378377  https://www.parkrun.org.uk/torvean/results/105/
+30/09/2023,2023,3b 5km,Yes,Plean Parkrun,Scott Jenkins,M,GBR,24:40.0,1,https://www.parkrun.org.uk/plean/results/223/  https://www.strava.com/activities/9947669351  https://www.parkrun.org.uk/plean/news/2023/09/30/juggling-milestones/
+24/09/2023,2023,3b 10km,Yes,Chester Zoo,EJ Coldham,F,GBR,58:23.0,?,https://www.strava.com/activities/9909298131
+24/09/2023,2023,3c 10km,Yes,Chester Zoo,JL Coldham,M,GBR,07:07.0,?,https://www.strava.com/activities/9909388387
+24/09/2023,2023,3b Half Marathon,Yes,Badger Challenge,Samuel Dean,M,USA,28:08.0,4,https://www.strava.com/activities/9912752839
+24/09/2023,2023,3b Half Marathon,Yes,Scottish Half Marathon,James McDiarmid,M,GBR,33:28.0,0,https://www.scottishhalfmarathon.com/results
+24/09/2023,2023,3b Marathon,Yes,Bedford Aerodrome,Tim Butler,M,GBR,07:53.0,?,https://results.runthrough.co.uk/myresults.aspx?uid=16487-4971-6-3584757
+23/09/2023,2023,3b 5km,Yes,Penallta Parkrun,Scott Jenkins,M,GBR,22:38.0,2,https://www.parkrun.org.uk/penallta/results/346/
+17/09/2023,2023,3b 10km,Yes,Tübingen Heritage Run,Peter Rottenbach,M,DEU,01:15.0,?,https://my.raceresult.com/248587/#0_128718 
+16/09/2023,2023,3b 5km,Yes,Holyrood Parkrun,James McDiarmid,M,GBR,19:53.0,?,https://www.parkrun.org.uk/holyrood/results/56/
+16/09/2023,2023,3b 5km,Yes,Coed Cefn-pwll-du Parkrun,Scott Jenkins,M,GBR,23:59.0,0,https://www.facebook.com/100070150012167/videos/3833914350163308  https://www.parkrun.org.uk/coedcefnpwlldu/results/103/
+10/09/2023,2023,3b Half Marathon,Yes,Harrisburg Half Marathon,Tim Ebersole,M,USA,42:57.0,?,https://www.strava.com/activities/9821889643  https://runsignup.com/Race/Results/15430
+09/09/2023,2023,3b 5km,Yes,Holyrood Parkrun,James McDiarmid,M,GBR,20:01.0,0,https://www.parkrun.org.uk/holyrood/results/55/
+09/09/2023,2023,4b 5km,No,Zuiderpark Parkrun,Scott Jenkins,M,GBR,37:32.0,50,https://www.facebook.com/reel/326772983079041  https://www.parkrun.co.nl/zuiderpark/results/95/  https://twitter.com/OonaghLewis/status/1700803926184911241?t=9Nu6QfJj-yCyN6Y2r3IbIA&s=19&fbclid=IwAR3C7MyJ8eWmpR_NLBeN_CmoOCdB-3nm4o3TKAWOvw4zOLdlvzax6GFUanU
+02/09/2023,2023,3b 5km,Yes,Holyrood Parkrun,James McDiarmid,M,GBR,19:39.0,0,https://www.parkrun.org.uk/holyrood/results/54/
+26/08/2023,2023,3b 5km,Yes,Holyrood Parkrun,James McDiarmid,M,GBR,19:43.0,?,https://twitter.com/BobakChampion/status/1695403676653764661?t=V1talFM3LhClas5Hx3vH-w&s=19
+26/08/2023,2023,3b 5km,Yes,Roberts Park Parkrun,Jake Lodge,M,GBR,20:11.0,2,https://www.parkrun.org.uk/robertspark/results/95/  https://www.strava.com/activities/9722525613
+26/08/2023,2023,3b 5km,Yes,Vogrie Parkrun,Scott Jenkins,M,GBR,23:09.0,0,https://www.strava.com/activities/9722797495  https://www.parkrun.org.uk/vogrie/results/245/
+26/08/2023,2023,3c 5km,Yes,Jersey Shore Womens 5km,Karly Swaim,F,USA,34:29.0,?,https://runsignup.com/Race/Results/21839#resultSetId-400750;perpage:100  https://www.facebook.com/photo/?fbid=10108409452955774&set=g.372157942956062
+22/08/2023,2023,3b 10km,Yes,Time Trial,David Tate,M,USA,59:43.0,?,https://twitter.com/dren_braves/status/1693825675399168506/photo/1
+19/08/2023,2023,3b 5km,Yes,Torvean Parkrun,James McDiarmid,M,GBR,20:19.0,0,https://www.parkrun.org.uk/torvean/results/99/?utm_medium=email&utm_source=resultsemail&utm_campaign=systememail
+19/08/2023,2023,3b 5km,Yes,Huddersfield Parkrun,Jake Lodge,M,GBR,21:58.0,2,https://www.strava.com/activities/9677079696 https://www.parkrun.org.uk/huddersfield/results/547/
+19/08/2023,2023,3b 5km,Yes,Ogrod Saski Parkrun,Kacper Suchora,M,POL,33:36.0,?,https://www.parkrun.pl/ogrodsaski/results/143/
+19/08/2023,2023,4b 5km,No,Perth Parkrun,Scott Jenkins,M,GBR,37:39.0,40,"https://www.parkrun.org.uk/perth/results/438/
 https://www.strava.com/activities/9677761242
 "
-19/08/2023,2023,3b 50km,Yes,Foxton Hounds Ultra,Tim Butler,M,GBR,06:47:47.00,?,https://www.joggling.co.uk/Marathon-List https://my.raceresult.com/257436/results  https://www.strava.com/activities/9679189803
-15/08/2023,2023,3b 5km,Yes,Time Trial,Samuel Dean,M,USA,00:18:04.00,?,https://www.strava.com/activities/9655725241
-14/08/2023,2023,3b Mile,Yes,Time Trial,Caleb Williams,M,USA,00:04:36.00,0,https://www.youtube.com/watch?v=ubG4stsEwPw
-14/08/2023,2023,3b Mile,Yes,Time Trial,Samuel Dean,M,USA,00:04:58.00,?,https://www.strava.com/activities/9648987682
-12/08/2023,2023,3b 5km,Yes,Penistone Parkrun,Jake Lodge,M,GBR,00:21:21.00,?,https://www.parkrun.org.uk/penistone/results/132/ https://www.strava.com/activities/9631463241
-12/08/2023,2023,4b 5km,No,West Links Parkrun,Scott Jenkins,M,GBR,00:32:36.00,30,https://www.strava.com/activities/9631204125  https://www.parkrun.org.uk/westlinks/news/2023/08/18/a-lesson-in-solidarity-west-links-parkrun-no-82/
-12/08/2023,2023,3b Marathon,Yes,Boulder Rez Marathon,Erick Sells,M,USA,03:32:10.00,?,https://my.raceresult.com/256528/#11_EA305B  https://www.strava.com/activities/9635073806/overview
-08/08/2023,2023,3b Mile,Yes,Ramsbottom Summer Mile,Jake Lodge,M,GBR,00:05:55.00,0,https://www.strava.com/activities/9609299484
-05/08/2023,2023,3b 5km,Yes,Holyrood Parkrun,James McDiarmid,M,GBR,00:20:28.00,0,https://www.parkrun.org.uk/parkrunner/8560660/
-05/08/2023,2023,3b 5km,Yes,The Pastures Parkrun,Jake Lodge,M,GBR,00:21:08.00,1,https://www.strava.com/activities/9585611785
-05/08/2023,2023,3b 5km,Yes,Newbiggin-by-the-Sea Parkrun,Scott Jenkins,M,GBR,00:24:48.00,2,"https://www.parkrun.org.uk/newbigginbythesea/results/234/
+19/08/2023,2023,3b 50km,Yes,Foxton Hounds Ultra,Tim Butler,M,GBR,47:47.0,?,https://www.joggling.co.uk/Marathon-List https://my.raceresult.com/257436/results  https://www.strava.com/activities/9679189803
+15/08/2023,2023,3b 5km,Yes,Time Trial,Samuel Dean,M,USA,18:04.0,?,https://www.strava.com/activities/9655725241
+14/08/2023,2023,3b Mile,Yes,Time Trial,Caleb Williams,M,USA,04:36.0,0,https://www.youtube.com/watch?v=ubG4stsEwPw
+14/08/2023,2023,3b Mile,Yes,Time Trial,Samuel Dean,M,USA,04:58.0,?,https://www.strava.com/activities/9648987682
+12/08/2023,2023,3b 5km,Yes,Penistone Parkrun,Jake Lodge,M,GBR,21:21.0,?,https://www.parkrun.org.uk/penistone/results/132/ https://www.strava.com/activities/9631463241
+12/08/2023,2023,4b 5km,No,West Links Parkrun,Scott Jenkins,M,GBR,32:36.0,30,https://www.strava.com/activities/9631204125  https://www.parkrun.org.uk/westlinks/news/2023/08/18/a-lesson-in-solidarity-west-links-parkrun-no-82/
+12/08/2023,2023,3b Marathon,Yes,Boulder Rez Marathon,Erick Sells,M,USA,32:10.0,?,https://my.raceresult.com/256528/#11_EA305B  https://www.strava.com/activities/9635073806/overview
+08/08/2023,2023,3b Mile,Yes,Ramsbottom Summer Mile,Jake Lodge,M,GBR,05:55.0,0,https://www.strava.com/activities/9609299484
+05/08/2023,2023,3b 5km,Yes,Holyrood Parkrun,James McDiarmid,M,GBR,20:28.0,0,https://www.parkrun.org.uk/parkrunner/8560660/
+05/08/2023,2023,3b 5km,Yes,The Pastures Parkrun,Jake Lodge,M,GBR,21:08.0,1,https://www.strava.com/activities/9585611785
+05/08/2023,2023,3b 5km,Yes,Newbiggin-by-the-Sea Parkrun,Scott Jenkins,M,GBR,24:48.0,2,"https://www.parkrun.org.uk/newbigginbythesea/results/234/
 https://www.strava.com/activities/9585830232"
-05/08/2023,2023,3b 5km,Yes,Woodley Parkrun,Stuart Humphries,M,GBR,00:28:03.00,?,https://www.parkrun.org.uk/woodley/results/489/
-30/07/2023,2023,3b 5km,Yes,EJC Joggling Open,Eden Katsir,M,IRL,00:21:24.00,?,https://www.joggling.pl/joggling-competitionszawody/2023-lublin-open.html
-30/07/2023,2023,3b 5km,Yes,EJC Joggling Open,Piotr Maciejewski,M,POL,00:22:14.00,?,https://www.joggling.pl/joggling-competitionszawody/2023-lublin-open.html
-30/07/2023,2023,3b 5km,Yes,EJC Joggling Open,Fabian Fehlhaber,M,DEU,00:22:55.00,?,https://www.joggling.pl/joggling-competitionszawody/2023-lublin-open.html
-30/07/2023,2023,3b 5km,Yes,EJC Joggling Open,Jarek Widomski,M,POL,00:24:22.00,?,https://www.joggling.pl/joggling-competitionszawody/2023-lublin-open.html
-30/07/2023,2023,3b 5km,Yes,EJC Joggling Open,Rimon Cahany,M,ISR,00:24:33.00,?,https://www.joggling.pl/joggling-competitionszawody/2023-lublin-open.html
-30/07/2023,2023,3b 5km,Yes,EJC Joggling Open,Kaudo Pilder,M,EST,00:24:55.00,?,https://www.joggling.pl/joggling-competitionszawody/2023-lublin-open.html
-30/07/2023,2023,3b 5km,Yes,EJC Joggling Open,Vaclav Peca,M,CZE,00:25:02.00,?,https://www.joggling.pl/joggling-competitionszawody/2023-lublin-open.html
-30/07/2023,2023,3b 5km,Yes,EJC Joggling Open,Scott Seltzer,M,ISR,00:25:33.00,?,https://www.joggling.pl/joggling-competitionszawody/2023-lublin-open.html
-30/07/2023,2023,3b 5km,Yes,EJC Joggling Open,Emanuele Lodigiani,M,ITA,00:26:15.00,?,https://www.joggling.pl/joggling-competitionszawody/2023-lublin-open.html
-30/07/2023,2023,3b 5km,Yes,EJC Joggling Open,Nicolas Fuchs,M,DEU,00:26:20.00,?,https://www.joggling.pl/joggling-competitionszawody/2023-lublin-open.html
-30/07/2023,2023,3b 5km,Yes,EJC Joggling Open,Tilman Kortenhaus,M,DEU,00:29:04.00,?,https://www.joggling.pl/joggling-competitionszawody/2023-lublin-open.html
-30/07/2023,2023,3b 5km,Yes,EJC Joggling Open,Peter Rottenbach,M,DEU,00:29:14.00,?,https://www.joggling.pl/joggling-competitionszawody/2023-lublin-open.html
-30/07/2023,2023,3b 5km,Yes,EJC Joggling Open,Iunya Inoue,M,JPN,00:30:16.00,?,https://www.joggling.pl/joggling-competitionszawody/2023-lublin-open.html
-30/07/2023,2023,3b 5km,Yes,EJC Joggling Open,Nils Berg,M,DEU,00:30:46.00,?,https://www.joggling.pl/joggling-competitionszawody/2023-lublin-open.html
-30/07/2023,2023,3b 5km,Yes,EJC Joggling Open,Elias Loehr,M,DEU,00:31:20.00,?,https://www.joggling.pl/joggling-competitionszawody/2023-lublin-open.html
-30/07/2023,2023,3b 5km,Yes,EJC Joggling Open,Juliane de Vries,F,DEU,00:31:25.00,?,https://www.joggling.pl/joggling-competitionszawody/2023-lublin-open.html
-30/07/2023,2023,3b 5km,Yes,EJC Joggling Open,Ting-En Chang,M,TWN,00:33:59.00,?,https://www.joggling.pl/joggling-competitionszawody/2023-lublin-open.html
-30/07/2023,2023,3b 5km,Yes,EJC Joggling Open,Martin Bartsch,M,DEU,00:35:44.00,?,https://www.joggling.pl/joggling-competitionszawody/2023-lublin-open.html
-30/07/2023,2023,3b 5km,Yes,EJC Joggling Open,Liya Bakhrakh,F,ISR,00:36:26.00,?,https://www.joggling.pl/joggling-competitionszawody/2023-lublin-open.html
-30/07/2023,2023,3b 5km,Yes,EJC Joggling Open,Anton Bartsch,M,DEU,00:39:27.00,?,https://www.joggling.pl/joggling-competitionszawody/2023-lublin-open.html
-29/07/2023,2023,3b 5km,Yes,Huddersfield Parkrun,Jake Lodge,M,GBR,00:21:00.00,3,"https://www.parkrun.org.uk/huddersfield/results/545/
+05/08/2023,2023,3b 5km,Yes,Woodley Parkrun,Stuart Humphries,M,GBR,28:03.0,?,https://www.parkrun.org.uk/woodley/results/489/
+30/07/2023,2023,3b 5km,Yes,EJC Joggling Open,Eden Katsir,M,IRL,21:24.0,?,https://www.joggling.pl/joggling-competitionszawody/2023-lublin-open.html
+30/07/2023,2023,3b 5km,Yes,EJC Joggling Open,Piotr Maciejewski,M,POL,22:14.0,?,https://www.joggling.pl/joggling-competitionszawody/2023-lublin-open.html
+30/07/2023,2023,3b 5km,Yes,EJC Joggling Open,Fabian Fehlhaber,M,DEU,22:55.0,?,https://www.joggling.pl/joggling-competitionszawody/2023-lublin-open.html
+30/07/2023,2023,3b 5km,Yes,EJC Joggling Open,Jarek Widomski,M,POL,24:22.0,?,https://www.joggling.pl/joggling-competitionszawody/2023-lublin-open.html
+30/07/2023,2023,3b 5km,Yes,EJC Joggling Open,Rimon Cahany,M,ISR,24:33.0,?,https://www.joggling.pl/joggling-competitionszawody/2023-lublin-open.html
+30/07/2023,2023,3b 5km,Yes,EJC Joggling Open,Kaudo Pilder,M,EST,24:55.0,?,https://www.joggling.pl/joggling-competitionszawody/2023-lublin-open.html
+30/07/2023,2023,3b 5km,Yes,EJC Joggling Open,Vaclav Peca,M,CZE,25:02.0,?,https://www.joggling.pl/joggling-competitionszawody/2023-lublin-open.html
+30/07/2023,2023,3b 5km,Yes,EJC Joggling Open,Scott Seltzer,M,ISR,25:33.0,?,https://www.joggling.pl/joggling-competitionszawody/2023-lublin-open.html
+30/07/2023,2023,3b 5km,Yes,EJC Joggling Open,Emanuele Lodigiani,M,ITA,26:15.0,?,https://www.joggling.pl/joggling-competitionszawody/2023-lublin-open.html
+30/07/2023,2023,3b 5km,Yes,EJC Joggling Open,Nicolas Fuchs,M,DEU,26:20.0,?,https://www.joggling.pl/joggling-competitionszawody/2023-lublin-open.html
+30/07/2023,2023,3b 5km,Yes,EJC Joggling Open,Tilman Kortenhaus,M,DEU,29:04.0,?,https://www.joggling.pl/joggling-competitionszawody/2023-lublin-open.html
+30/07/2023,2023,3b 5km,Yes,EJC Joggling Open,Peter Rottenbach,M,DEU,29:14.0,?,https://www.joggling.pl/joggling-competitionszawody/2023-lublin-open.html
+30/07/2023,2023,3b 5km,Yes,EJC Joggling Open,Iunya Inoue,M,JPN,30:16.0,?,https://www.joggling.pl/joggling-competitionszawody/2023-lublin-open.html
+30/07/2023,2023,3b 5km,Yes,EJC Joggling Open,Nils Berg,M,DEU,30:46.0,?,https://www.joggling.pl/joggling-competitionszawody/2023-lublin-open.html
+30/07/2023,2023,3b 5km,Yes,EJC Joggling Open,Elias Loehr,M,DEU,31:20.0,?,https://www.joggling.pl/joggling-competitionszawody/2023-lublin-open.html
+30/07/2023,2023,3b 5km,Yes,EJC Joggling Open,Juliane de Vries,F,DEU,31:25.0,?,https://www.joggling.pl/joggling-competitionszawody/2023-lublin-open.html
+30/07/2023,2023,3b 5km,Yes,EJC Joggling Open,Ting-En Chang,M,TWN,33:59.0,?,https://www.joggling.pl/joggling-competitionszawody/2023-lublin-open.html
+30/07/2023,2023,3b 5km,Yes,EJC Joggling Open,Martin Bartsch,M,DEU,35:44.0,?,https://www.joggling.pl/joggling-competitionszawody/2023-lublin-open.html
+30/07/2023,2023,3b 5km,Yes,EJC Joggling Open,Liya Bakhrakh,F,ISR,36:26.0,?,https://www.joggling.pl/joggling-competitionszawody/2023-lublin-open.html
+30/07/2023,2023,3b 5km,Yes,EJC Joggling Open,Anton Bartsch,M,DEU,39:27.0,?,https://www.joggling.pl/joggling-competitionszawody/2023-lublin-open.html
+29/07/2023,2023,3b 5km,Yes,Huddersfield Parkrun,Jake Lodge,M,GBR,21:00.0,3,"https://www.parkrun.org.uk/huddersfield/results/545/
 https://www.strava.com/activities/9541633115"
-29/07/2023,2023,3b 5km,Yes,Saski Garden Parkrun,Piotr Maciejewski,M,POL,00:23:29.00,2,https://www.instagram.com/p/CvTzairoUBX/?img_index=1 https://www.parkrun.pl/ogrodsaski/results/140/  
-29/07/2023,2023,3b 5km,Yes,Morecambe Prom Parkrun,Nick Burns,M,GBR,00:34:45.00,?,https://www.parkrun.org.uk/morecambeprom/results/152
-29/07/2023,2023,3b 5km,Yes,Krakow Parkrun,Kacper Suchora,M,POL,00:35:19.00,?,https://www.instagram.com/p/CvSjtfIIDmt/  https://www.parkrun.pl/krakow/results/471/
-29/07/2023,2023,4b 5km,No,Lochore Meadows Parkrun,Scott Jenkins,M,GBR,00:42:52.00,50,"https://www.strava.com/activities/9541834029
+29/07/2023,2023,3b 5km,Yes,Saski Garden Parkrun,Piotr Maciejewski,M,POL,23:29.0,2,https://www.instagram.com/p/CvTzairoUBX/?img_index=1 https://www.parkrun.pl/ogrodsaski/results/140/  
+29/07/2023,2023,3b 5km,Yes,Morecambe Prom Parkrun,Nick Burns,M,GBR,34:45.0,?,https://www.parkrun.org.uk/morecambeprom/results/152
+29/07/2023,2023,3b 5km,Yes,Krakow Parkrun,Kacper Suchora,M,POL,35:19.0,?,https://www.instagram.com/p/CvSjtfIIDmt/  https://www.parkrun.pl/krakow/results/471/
+29/07/2023,2023,4b 5km,No,Lochore Meadows Parkrun,Scott Jenkins,M,GBR,42:52.0,50,"https://www.strava.com/activities/9541834029
 https://www.parkrun.org.uk/lochoremeadows/results/183/
 "
-27/07/2023,2023,3b Mile,Yes,Time Trial,Rick Kwiatkowski,M,USA,00:07:48.00,?,https://www.strava.com/activities/9534592553
-26/07/2023,2023,3b Marathon,Yes,Great Barrow Challenge Day 5,Tim Butler,M,GBR,04:41:09.00,?,https://www.joggling.co.uk/Marathon-List
-24/07/2023,2023,3b 5km,Yes,"Deseret News Marathon 5k, Utah",David Tate,M,USA,00:26:26.00,0,https://twitter.com/dren_braves/status/1683494655470518278?t=ctWFUgmkvj__L-g09rS9MA&s=19      https://www.brooksee.com/des/results?sort=&race=167024&date=&event=5K&gender=&division=&search=Tate&loc_168380=&page_168380=1&size_168380=25&loc_168381=&page_168381=1&size_168381=25&loc_168382=&page_168382=1&size_168382=25&loc_168383=&page_168383=1&size_168383=25&loc_168384=&page_168384=1&size_168384=25
-22/07/2023,2023,3b 5km,Yes,Holyrood Parkrun ,James McDiarmid,M,GBR,00:20:11.00,0,https://www.parkrun.org.uk/holyrood/results/48/?utm_medium=email&utm_source=resultsemail&utm_campaign=systememail
-22/07/2023,2023,3b 5km,Yes,Aberystwyth Parkrun,Derrick Adams,M,GBR,00:26:16.00,?,https://www.parkrun.org.uk/aberystwyth/results/497/ Reports of Derrick joggling on Facebook this week
-22/07/2023,2023,3b 5km,Yes,Jubilee Parkrun,Scott Jenkins,M,GBR,00:28:06.00,0,https://www.strava.com/activities/9498231178  https://www.parkrun.org.uk/jubilee/results/110/
-16/07/2023,2023,3b Half Marathon,Yes,Ilkley Half Marathon,Chris Edwin,M,GBR,01:22:18.00,0,https://www.sportstimingsolutions.co.uk/rd.php?id=484
-16/07/2023,2023,3b Half Marathon,Yes,Ilkley Half Marathon,Scott Jenkins,M,GBR,01:44:28.00,0,https://www.sportstimingsolutions.co.uk/rd.php?id=484
-15/07/2023,2023,3b 5km,Yes,Holyrood Parkrun,James McDiarmid,M,GBR,00:21:09.00,2,
-15/07/2023,2023,3b 5km,Yes,Huddersfield Parkrun,Jake Lodge,M,GBR,00:22:12.00,4,https://www.parkrun.org.uk/huddersfield/results/543/ https://www.strava.com/activities/9454005319
-15/07/2023,2023,3b 5km,Yes,Roberts Park Parkrun,Scott Jenkins,M,GBR,00:24:39.00,2,https://www.parkrun.org.uk/robertspark/results/89/ https://www.strava.com/activities/9454347891
-15/07/2023,2023,3b 5km,Yes,Roberts Park Parkrun,Chris Edwin,M,GBR,00:24:40.00,0,https://www.parkrun.org.uk/robertspark/results/89/ https://www.strava.com/activities/9453836097
-10/07/2023,2023,3b Mile,Yes,Time Trial,Tim Ebersole,M,USA,00:06:11.00,?,https://www.strava.com/activities/9426849905
-08/07/2023,2023,3b 5km,Yes,Stamford Park Parkrun,Jake Lodge,M,GBR,00:21:38.00,?,https://www.parkrun.org.uk/stamfordpark/results/341/  https://www.strava.com/activities/9409921616
-08/07/2023,2023,3b 5km,Yes,St Andrews Parkrun,Scott Jenkins,M,GBR,00:22:19.00,0,https://www.parkrun.org.uk/standrews/results/489/
-07/07/2023,2023,3b 10km,Yes,"SoJo Glow Run, South Jordan, Utah",David Tate,M,USA,00:59:59.00,?,https://twitter.com/dren_braves/status/1677692169803673600
-01/07/2023,2023,3b 5km,Yes,Polkemmet Country Parkrun,Scott Jenkins,M,GBR,00:23:18.00,0,https://www.parkrun.org.uk/polkemmetcountry/results/137/
-01/07/2023,2023,3b 5km,Yes,FSM China 5k,Dana Lee Ling,M,FSM,00:56:57.00,1,https://www.strava.com/activities/9364589789 https://www.facebook.com/100091873519711/posts/pfbid02xXwXYu6tfDkMg1nxegsv8UwobrTHehg6BjDce9DrsEsebX9qbjhPtWRQ9S2ZL9H4l/?app=fbl 
-24/06/2023,2023,3b 5km,Yes,Holyrood Parkrun,James McDiarmid,M,GBR,00:21:38.00,?,https://www.parkrun.org.uk/holyrood/results/44/
-18/06/2023,2023,3b 50km,Yes,Trackathon,Tim Butler,M,GBR,05:58:05.00,?,https://www.joggling.co.uk/Marathon-List
-17/06/2023,2023,3b 5km,Yes,Milano Nord Parkrun,Scott Jenkins,M,GBR,00:28:57.00,0,https://www.strava.com/activities/9280386127  https://www.parkrun.it/milanonord/results/271/
-16/06/2023,2023,3b Half Marathon,Yes,"Nacht Van Vlaanderen Half Marathon, Belgium",Toon Witters,M,BEL,01:53:11.00,?,https://www.strava.com/activities/9278465811 https://www.focus-wtv.be/nieuws/toon-loopt-halve-marathon-op-blote-voeten-en-al-jonglerend
-10/06/2023,2023,3b 5km,Yes,Holyrood Parkrun,James McDiarmid,M,GBR,00:22:19.00,6,https://www.parkrun.org.uk/holyrood/results/42/
-10/06/2023,2023,3b 5km,Yes,Dinton Pastures Parkrun,Stuart Humphries,M,GBR,00:27:22.00,?,https://www.parkrun.org.uk/dintonpastures/results/189/
-04/06/2023,2023,3b Half Marathon,Yes,Cork Half Marathon,Scott Jenkins,M,GBR,01:47:39.00,0,https://www.strava.com/activities/9200562937  https://www.corkathletics.org/latest-results/2023/434-june/2907-cork-city-half-marathon-results-june-2023.html
-04/06/2023,2023,3b Ultra (28.5m),No,Butterfly Run,Tim Butler,M,GBR,05:39:52.00,?,https://www.joggling.co.uk/Marathon-List
-28/05/2023,2023,3b Half Marathon,Yes,Edinburgh Half Marathon,Scott Jenkins,M,GBR,01:27:48.00,2,https://www.strava.com/activities/9154792920
-27/05/2023,2023,3b 5km,Yes,Ottawa,Michael-Lucien Bergeron,M,CAN,00:17:24.00,?,https://www.strava.com/activities/9152812476
-27/05/2023,2023,3b 5km,Yes,Dunfermline Parkrun,Scott Jenkins,M,GBR,00:20:44.00,0,https://www.parkrun.org.uk/dunfermline/results/311  https://www.strava.com/activities/9148516853
-26/05/2023,2023,3b 3km,Yes,Glasgow Green,Scott Jenkins,M,GBR,00:10:21.00,0,https://www.strava.com/activities/9143369867
-20/05/2023,2023,3b 5km,Yes,Meadowmill Parkrun,Scott Jenkins,M,GBR,00:20:56.00,3,https://www.parkrun.org.uk/meadowmill/results/135  https://www.strava.com/activities/9104572768
-20/05/2023,2023,3b 5km,Yes,Aberystwyth Parkrun,Derrick Adams,M,GBR,00:26:36.00,0,https://www.parkrun.org.uk/aberystwyth/results/488/  Twitter post (Found by Chris E)
-14/05/2023,2023,3b 5km,Yes,Time Trial,Toon Witters,M,BEL,00:23:41.00,1,"https://www.strava.com/activities/9068289058, barefoot"
-14/05/2023,2023,3c 10km,Yes,Blackpool,JL Coldham,M,GBR,01:07:14.00,?,Clubs. https://www.strava.com/activities/9069210875  https://www.facebook.com/526246301/videos/1519666768437135/  https://www.sportstimingsolutions.co.uk/rcd.php?id=472&bib=1252
-14/05/2023,2023,3b Marathon,Yes,Leeds Marathon,Chris Edwin,M,GBR,03:09:13.00,1,https://www.strava.com/activities/9069308254
-14/05/2023,2023,3b Marathon,Yes,Leeds Marathon,Tim Butler,M,GBR,04:41:11.00,?,https://www.strava.com/activities/9071024334
-13/05/2023,2023,3b 10km,Yes,"Penicuik, Scotland",Scott Jenkins,M,GBR,00:40:28.00,0,https://www.strava.com/activities/9062494677
-07/05/2023,2023,3b Marathon,Yes,Lincoln Marathon,Trevor McQuay,M,USA,04:30:42.00,?,https://www.mtecresults.com/runner/show?race=14950&rid=554 https://www.strava.com/activities/9029190962
-06/05/2023,2023,3b 5km,Yes,Holyrood Parkrun,Scott Jenkins,M,GBR,00:24:18.00,2,https://www.parkrun.org.uk/holyrood/results/38  https://www.strava.com/activities/9020536793
-23/04/2023,2023,3b Half Marathon,Yes,St. Luke's Half Marathon,Scott Boehret,M,USA,01:48:43.00,1,https://runsignup.com/Race/Results/11383/?customResultsPageId=61903&segmentId=406332&row=261
-23/04/2023,2023,3b Half Marathon,Yes,Rock n Roll Nashville,John Dombach,M,USA,01:56:47.00,6,https://www.runrocknroll.com/nashville-results   https://www.instagram.com/p/CrUOvmqpPuF/
-22/04/2023,2023,3b 5km,Yes,Tollcross Parkrun,Scott Jenkins,M,GBR,00:20:57.00,0,https://www.strava.com/activities/8935351158
-22/04/2023,2023,3b 10km,Yes,"Richmond, VA",Jonathan Austin,M,USA,00:51:15.00,0,Email exchange
-22/04/2023,2023,3b 10km,Yes,"SoJo Earth Day 10k, Utah",David Tate,M,USA,00:55:24.00,0,https://results.raceroster.com/en-US/results/detail/fk5f3msqrvvbd33n    https://twitter.com/dren_braves/status/1649826780231110656?t=gCRH4mIKsuIswg-kz8Wp1A&s=19
-16/04/2023,2023,3b Marathon,Yes,Manchester Marathon,Chris Edwin,M,GBR,03:10:30.00,0,
-15/04/2023,2023,3b 5km,Yes,Vogrie Parkrun,Scott Jenkins,M,GBR,00:20:33.00,0,https://www.strava.com/activities/8893490771
-08/04/2023,2023,3b 5km,Yes,Edinburgh Parkrun,Scott Jenkins,M,GBR,00:20:52.00,1,https://www.strava.com/activities/8852459895
-02/04/2023,2023,3b 5km,Yes,Southampton 5km,Kevin Sawers,M,GBR,00:32:04.00,?,https://www.strava.com/activities/8817698457   https://dbmaxresults.co.uk/results.aspx?CId=16421&RId=405&EId=6&dt=0&PageNo=2&adv=0
-01/04/2023,2023,3b 5km,Yes,Meadowmill Parkrun,Scott Jenkins,M,GBR,00:20:18.00,0,https://www.strava.com/activities/8811969159
-01/04/2023,2023,3b 5km,Yes,Preston Park Parkrun,Jake Lodge,M,GBR,00:23:21.00,?,https://www.parkrun.org.uk/prestonpark/results/440/  https://www.strava.com/activities/8814301066
-25/03/2023,2023,3b 5km,Yes,Livingston Parkrun,Scott Jenkins,M,GBR,00:27:59.00,0,https://www.strava.com/activities/8773238448
-25/03/2023,2023,3b Ultra (27.5m),No,Great British Seaside Challenge,Tim Butler,M,GBR,05:26:01.00,?,https://www.joggling.co.uk/Marathon-List
-19/03/2023,2023,3b Half Marathon,Yes,Wigan Half Marathon,Chris Edwin,M,GBR,01:22:19.00,0,
-18/03/2023,2023,3b 5km,Yes,Oriam Parkrun,Scott Jenkins,M,GBR,00:20:10.00,0,https://www.strava.com/activities/8733520825
-18/03/2023,2023,3b 5km,Yes,Nobles Parkrun,Jake Lodge,M,GBR,00:22:34.00,?,https://www.parkrun.org.uk/nobles/results/224/  https://www.parkrun.org.uk/nobles/news/2023/03/21/nobles-parkrun-event-224/   https://www.instagram.com/p/Cp7aQ-iDjkc/
-18/03/2023,2023,3b 5km,Yes,"SoJo Gold Rush Race 5k, Utah",David Tate,M,USA,00:27:12.00,0,https://results.raceroster.com/en-US/results/detail/q2ujswhv74k37m4v     https://twitter.com/dren_braves/status/1638301785600425985?t=6CoSh0lgpz_2gcWnjjedGQ&s=19
-11/03/2023,2023,3b 5km,Yes,Torvean Parkrun,Scott Jenkins,M,GBR,00:26:21.00,0,https://www.strava.com/activities/8695029181
-07/03/2023,2023,3b Marathon,Yes,Big Bear Elephant Run,Tim Butler,M,GBR,04:58:04.00,?,https://www.joggling.co.uk/Marathon-List
-05/03/2023,2023,3b Marathon,Yes,Tokyo Marathon,Barak Hirschowitz,M,USA,04:10:00.00,0,https://www.marathon.tokyo/2023/result/detail.php
-05/03/2023,2023,3b Marathon,Yes,Tokyo Marathon,Jack Hirschowitz,M,USA,04:55:10.00,0,https://www.marathon.tokyo/2023/result/detail.php
-04/03/2023,2023,3b 5km,Yes,"Queen's, Glasgow Parkrun",Scott Jenkins,M,GBR,00:22:41.00,0,https://www.strava.com/activities/8656799309
-22/02/2023,2023,3b Half Marathon,Yes,Time Trial,Jake Lodge,M,GBR,01:45:28.00,?,https://www.strava.com/activities/8602663011
-19/02/2023,2023,3b 5km,Yes,Roberts Park Parkrun,Chris Edwin,M,GBR,00:19:12.00,1,https://www.parkrun.org.uk/robertspark/results/19/      https://www.facebook.com/108529600921199/posts/pfbid0xiw65sANFevSWGv3avyQoS8v81v9Vyvz83nWbR9Zx7TBRMxYKAk6Xc4CW6C9UAoTl/?app=fbl
-19/02/2023,2023,3b 5km,Yes,Roberts Park Parkrun,Ralph Kidner,M,GBR,00:34:13.00,?,https://www.parkrun.org.uk/robertspark/results/19/      https://www.facebook.com/108529600921199/posts/pfbid0xiw65sANFevSWGv3avyQoS8v81v9Vyvz83nWbR9Zx7TBRMxYKAk6Xc4CW6C9UAoTl/?app=fbl
-19/02/2023,2023,3b Marathon,Yes,Bingley,Tim Butler,M,GBR,04:46:15.00,?,https://www.joggling.co.uk/Marathon-List
-12/02/2023,2023,3b Marathon,Yes,"Brandon Park, Suffolk",Tim Butler,M,GBR,04:51:10.00,?,https://www.joggling.co.uk/Marathon-List
-11/02/2023,2023,3b 5km,Yes,Vogrie Parkrun,Scott Jenkins,M,GBR,00:24:48.00,1,https://www.strava.com/activities/8541362997
-10/02/2023,2023,3b 5km,Yes,Park im. Jana Pawla II Parkrun,Kacper Suchora,M,POL,00:27:06.00,?,
-04/02/2023,2023,3b 5km,Yes,Hay Lodge Parkrun,Scott Jenkins,M,GBR,00:20:47.00,0,https://www.strava.com/activities/8502123456
-28/01/2023,2023,3b 5km,Yes,Falkirk Parkrun,Scott Jenkins,M,GBR,00:23:29.00,1,https://www.strava.com/activities/8464216907
-28/01/2023,2023,3b 5km,Yes,Chevin Forest Parkrun,Jake Lodge,M,GBR,00:24:48.00,?,https://www.parkrun.org.uk/chevinforest/results/73/  https://www.strava.com/activities/8464067384
-27/01/2023,2023,3b Marathon,Yes,Knaresmire Edge Rewind,Tim Butler,M,GBR,04:46:55.00,?,https://www.joggling.co.uk/Marathon-List
-21/01/2023,2023,3b 5km,Yes,Lochend Woods Parkrun,Scott Jenkins,M,GBR,00:20:58.00,0,https://www.strava.com/activities/8426310028
-14/01/2023,2023,3b 5km,Yes,Brighouse Parkrun,Jake Lodge,M,GBR,00:22:21.00,4,https://www.strava.com/activities/8390331189  https://www.parkrun.org.uk/brighouse/results/231/
-07/01/2023,2023,3b 5km,Yes,Pobalscoil Na Trionoide Parkrun,Brian Linehan,M,IRL,00:23:25.00,?,https://www.parkrun.ie/pobalscoilnatrionoide/results/44/   https://www.facebook.com/profile/100067922504955/search/?q=juggling
-30/12/2022,2022,3b Marathon,Yes,Bridlington,Tim Butler,M,GBR,04:44:55.00,?,https://www.joggling.co.uk/Marathon-List
-24/12/2022,2022,3b 5km,Yes,Burnham and Highbridge Parkrun,Scott Jenkins,M,GBR,00:23:47.00,0,https://www.strava.com/activities/8284952061
-17/12/2022,2022,3b Marathon,Yes,Maramile,Tim Butler,M,GBR,04:18:29.00,?,https://www.joggling.co.uk/Marathon-List
-03/12/2022,2022,3b 10km,Yes,Forchheimer Nikolauslauf,Peter Meyer,M,DEU,00:59:43.00,4,https://www.hdsports.at/laufen/forchheimer-nikolauslauf  http://home.mnet-online.de/joggling/aboutme_d.htm
-26/11/2022,2022,3b 5km,Yes,Holyrood Parkrun,Scott Jenkins,M,GBR,00:23:56.00,?,https://www.strava.com/activities/8170151768
-20/11/2022,2022,3b Marathon,Yes,Maravan,Tim Butler,M,GBR,04:27:07.00,?,https://www.joggling.co.uk/Marathon-List
-19/11/2022,2022,3b 5km,Yes,Kirkcaldy Parkrun,Scott Jenkins,M,GBR,00:21:47.00,0,https://www.strava.com/activities/8138686226
-19/11/2022,2022,3b 5km,Yes,Prospet Parkrun,Stuart Humphries,M,GBR,00:25:40.00,?,https://www.facebook.com/watch/?v=1163098037643456   https://www.parkrun.org.uk/prospect/results/154/
-06/11/2022,2022,3b Marathon,Yes,New York City Marathon,Barak Hirschowitz,M,USA,04:51:10.00,?,https://results.nyrr.org/event/M2022/finishers#search=Barak%2520Hirschowitz
-06/11/2022,2022,3b Marathon,Yes,New York City Marathon,Jack Hirschowitz,M,USA,05:11:39.00,?,https://results.nyrr.org/event/M2022/finishers#page=1&search=Jack%2520Hirschowitz
-05/11/2022,2022,3b 5km,Yes,University of Stirling Parkrun,Scott Jenkins,M,GBR,00:22:54.00,0,
-05/11/2022,2022,3b 10km,Yes,Time Trial,Henry Wellenstein,M,USA,00:33:34.00,?,https://www.strava.com/activities/8074621672
-16/10/2022,2022,3b Marathon,Yes,Yorkshire Marathon,Tim Butler,M,GBR,04:24:32.00,?,https://www.joggling.co.uk/Marathon-List
-15/10/2022,2022,3b 5km,Yes,Livingston Parkrun,Scott Jenkins,M,GBR,00:24:19.00,?,https://www.strava.com/activities/7965340687
-09/10/2022,2022,3b Marathon,Yes,Chicago Marathon,Perry Romanowski,M,USA,03:59:49.00,?,https://chicago-history.r.mikatiming.com/2021/?pid=search
-09/10/2022,2022,3b Marathon,Yes,Chicago Marathon,Barak Hirschowitz,M,USA,04:42:47.00,?,https://results.chicagomarathon.com/2022/?pid=search&pidp=start
-09/10/2022,2022,3b Marathon,Yes,Chicago Marathon,Jack Hirschowitz,M,USA,05:03:24.00,?,https://results.chicagomarathon.com/2022/?pid=search&pidp=start
-08/10/2022,2022,3b 5km,Yes,Pontypool Parkrun,Jake Lodge,M,GBR,00:23:21.00,?,https://www.strava.com/activities/7928899111  https://www.parkrun.org.uk/pontypool/results/372/
-02/10/2022,2022,3b Marathon,Yes,London Marathon,Barak Hirschowitz,M,USA,04:15:35.00,?,https://results.tcslondonmarathon.com/2022/?pid=search
-02/10/2022,2022,3b Marathon,Yes,Ruddy Rothwell Cakeathon,Tim Butler,M,GBR,04:53:16.00,?,https://www.joggling.co.uk/Marathon-List
-02/10/2022,2022,3b Marathon,Yes,London Marathon,Jack Hirschowitz,M,USA,05:03:53.00,?,https://results.tcslondonmarathon.com/2022/?pid=search
-01/10/2022,2022,3b 5km,Yes,Oriam Parkrun,Scott Jenkins,M,GBR,00:22:13.00,0,https://www.strava.com/activities/7893388827
-25/09/2022,2022,3b Marathon,Yes,Heartland Marathon,Trevor McQuay,M,USA,03:57:48.00,?,https://omaharun.org/wp-content/uploads/2022/10/ORCNewsletter_Fall-2022.pdf
-25/09/2022,2022,3b Marathon,Yes,Rutland Water Marathon,Tim Butler,M,GBR,04:33:19.00,?,https://www.joggling.co.uk/Marathon-List
-24/09/2022,2022,3b 5km,Yes,Vogrie Parkrun,Scott Jenkins,M,GBR,00:22:22.00,?,https://www.strava.com/activities/7858042399
-24/09/2022,2022,3b 5km,Yes,Marple Parkrun,Jake Lodge,M,GBR,00:27:33.00,?,https://www.parkrun.org.uk/marple/results/475/ https://www.strava.com/activities/7857853981
-17/09/2022,2022,3b Half Marathon,Yes,Oslo Half Marathon,Jake Lodge,M,GBR,01:49:18.00,?,https://www.strava.com/activities/7822440712  https://live.ultimate.dk/desktop/front/index.php?eventid=5388&ignoreuseragent=true
-11/09/2022,2022,3b Half Marathon,Yes,"Harrisburg Half Marathon, PA",Tim Ebersole,M,USA,01:36:28.00,?,https://runsignup.com/Race/Results/15430#resultSetId-336858;perpage:100
-10/09/2022,2022,3b 5km,Yes,Edinburgh Parkrun,Scott Jenkins,M,GBR,00:23:48.00,?,
-27/08/2022,2022,3b Ultra (49.6m),No,12 Hour Back to School Run,Tim Butler,M,GBR,11:40:32.00,?,https://www.joggling.co.uk/Marathon-List
-20/08/2022,2022,3b 5km,Yes,Glen River Parkrun,Brian Linehan,M,IRL,00:24:16.00,?,https://www.parkrun.ie/glenriver/results/119/    https://www.instagram.com/p/Che91wjjOL1/
-09/08/2022,2022,3b Mile,Yes,Ramsbottom Summer Mile,Jake Lodge,M,GBR,00:06:24.00,?,https://my.raceresult.com/214433/results  https://www.strava.com/activities/7610827072
-08/08/2022,2022,3b 5km,Yes,"North Beach Parkrun, Durban, South Africa",Gavin Levenstein,M,ZAF,00:22:33.00,?,https://www.parkrun.co.za/northbeach/results/409/
-05/08/2022,2022,3b 50km,Yes,Double Blinkathon,Tim Butler,M,GBR,05:34:59.00,?,https://www.joggling.co.uk/Marathon-List
-30/07/2022,2022,3b 5km,Yes,Irchester Country Parkrun,Scott Jenkins,M,GBR,00:23:43.00,?,
-28/07/2022,2022,3b 5km,Yes,Time Trial,John Baker,M,USA,00:16:56.00,?,https://www.instagram.com/p/CgiOHBcBGU6/
-23/07/2022,2022,3b 5km,Yes,Newent Parkrun,Scott Jenkins,M,GBR,00:25:43.00,2,
-23/07/2022,2022,3b Ultra (28m),No,Conquer the Castle,Tim Butler,M,GBR,05:27:25.00,?,https://www.joggling.co.uk/Marathon-List
-10/07/2022,2022,3b 10km,Yes,Time Trial,Michael-Lucien Bergeron,M,CAN,00:34:47.00,?,
-10/07/2022,2022,3b Half Marathon,Yes,Ilkely Half Marathon,Chris Edwin,M,GBR,01:41:40.00,0,
-09/07/2022,2022,3b 5km,Yes,Abingdon Parkrun,Scott Jenkins,M,GBR,00:26:58.00,?,
-03/07/2022,2022,3b 5 Mile,No,Endure24 Leeds,Jordan Evans,M,GBR,00:35:33.00,?,https://results.resultsbase.net/myresults.aspx?uid=8-3599-1-970782
-03/07/2022,2022,3b 5 Mile,No,Endure24 Leeds,Jordan Evans,M,GBR,00:35:35.00,?,https://results.resultsbase.net/myresults.aspx?uid=8-3599-1-970787
-03/07/2022,2022,3b 5 Mile,No,Endure24 Leeds,Jake Lodge,M,GBR,00:43:52.00,?,https://results.resultsbase.net/myresults.aspx?uid=8-3599-1-970785
-03/07/2022,2022,3b 5 Mile,No,Endure24 Leeds,Jake Lodge,M,GBR,00:46:18.00,?,https://results.resultsbase.net/myresults.aspx?uid=8-3599-1-970788
-03/07/2022,2022,3b 5 Mile,No,Endure24 Leeds,Jake Lodge,M,GBR,00:54:03.00,?,https://results.resultsbase.net/myresults.aspx?uid=8-3599-1-970780
-03/07/2022,2022,3b 5 Mile,No,Endure24 Leeds,Ralph Kidner,M,GBR,00:56:28.00,?,https://results.resultsbase.net/myresults.aspx?uid=8-3599-1-970781
-03/07/2022,2022,3b 5 Mile,No,Endure24 Leeds,Stuart Humphries,M,GBR,00:58:42.00,?,https://results.resultsbase.net/myresults.aspx?uid=8-3599-1-970778
-03/07/2022,2022,3b 5 Mile,No,Endure24 Leeds,Dominic Lodge,M,GBR,00:59:21.00,?,https://results.resultsbase.net/myresults.aspx?uid=8-3599-1-970779
-03/07/2022,2022,3b 5 Mile,No,Endure24 Leeds,Dominic Lodge,M,GBR,00:59:57.00,?,https://results.resultsbase.net/myresults.aspx?uid=8-3599-1-970784
-03/07/2022,2022,3b 5 Mile,No,Endure24 Leeds,Ralph Kidner,M,GBR,00:59:58.00,?,https://results.resultsbase.net/myresults.aspx?uid=8-3599-1-970786
-03/07/2022,2022,3b 5 Mile,No,Endure24 Leeds,Scott Jenkins,M,GBR,01:01:48.00,?,https://results.resultsbase.net/myresults.aspx?uid=8-3599-1-970783
-03/07/2022,2022,3b 5 Mile,No,Endure24 Leeds,Scott Jenkins,M,GBR,01:02:28.00,?,https://results.resultsbase.net/myresults.aspx?uid=8-3599-1-970777
-02/07/2022,2022,3b 5km,Yes,York Parkrun,Jordan Evans,M,GBR,00:20:59.00,?,https://www.parkrun.org.uk/york/results/417/
-02/07/2022,2022,3b 5km,Yes,York Parkrun,Dominic Lodge,M,GBR,00:25:22.00,?,https://www.parkrun.org.uk/york/results/417/
-02/07/2022,2022,3b 5km,Yes,York Parkrun,Jake Lodge,M,GBR,00:27:20.00,?,https://www.parkrun.org.uk/york/results/417/
-02/07/2022,2022,3b 5km,Yes,York Parkrun,Scott Jenkins,M,GBR,00:31:57.00,0,https://www.parkrun.org.uk/york/results/417/
-02/07/2022,2022,3b 5 Mile,No,Endure24 Leeds,Jordan Evans,M,GBR,00:32:36.00,?,https://results.resultsbase.net/myresults.aspx?uid=8-3599-1-970764
-02/07/2022,2022,3b 5 Mile,No,Endure24 Leeds,Jordan Evans,M,GBR,00:33:47.00,?,https://results.resultsbase.net/myresults.aspx?uid=8-3599-1-970770
-02/07/2022,2022,3b 5 Mile,No,Endure24 Leeds,Jordan Evans,M,GBR,00:34:52.00,?,https://results.resultsbase.net/myresults.aspx?uid=8-3599-1-970776
-02/07/2022,2022,3b 5 Mile,No,Endure24 Leeds,Dominic Lodge,M,GBR,00:35:32.00,?,https://results.resultsbase.net/myresults.aspx?uid=8-3599-1-970767
-02/07/2022,2022,3b 5 Mile,No,Endure24 Leeds,Jordan Evans,M,GBR,00:36:29.00,?,https://results.resultsbase.net/myresults.aspx?uid=8-3599-1-970790
-02/07/2022,2022,3b 5 Mile,No,Endure24 Leeds,Dominic Lodge,M,GBR,00:37:19.00,?,https://results.resultsbase.net/myresults.aspx?uid=8-3599-1-970773
-02/07/2022,2022,3b 5 Mile,No,Endure24 Leeds,Dominic Lodge,M,GBR,00:38:32.00,?,https://results.resultsbase.net/myresults.aspx?uid=8-3599-1-970761
-02/07/2022,2022,3b 5 Mile,No,Endure24 Leeds,Scott Jenkins,M,GBR,00:40:10.00,?,https://results.resultsbase.net/myresults.aspx?uid=8-3599-1-970765
-02/07/2022,2022,3b 5 Mile,No,Endure24 Leeds,Jake Lodge,M,GBR,00:41:51.00,?,https://results.resultsbase.net/myresults.aspx?uid=8-3599-1-970762
-02/07/2022,2022,3b 5 Mile,No,Endure24 Leeds,Scott Jenkins,M,GBR,00:43:01.00,?,https://results.resultsbase.net/myresults.aspx?uid=8-3599-1-970771
-02/07/2022,2022,3b 5 Mile,No,Endure24 Leeds,Jake Lodge,M,GBR,00:43:12.00,?,https://results.resultsbase.net/myresults.aspx?uid=8-3599-1-970768
-02/07/2022,2022,3b 5 Mile,No,Endure24 Leeds,Jake Lodge,M,GBR,00:44:53.00,?,https://results.resultsbase.net/myresults.aspx?uid=8-3599-1-970774
-02/07/2022,2022,3b 5 Mile,No,Endure24 Leeds,Stuart Humphries,M,GBR,00:48:20.00,?,https://results.resultsbase.net/myresults.aspx?uid=8-3599-1-970766
-02/07/2022,2022,3b 5 Mile,No,Endure24 Leeds,Scott Jenkins,M,GBR,00:49:11.00,?,https://results.resultsbase.net/myresults.aspx?uid=8-3599-1-970789
-02/07/2022,2022,3b 5 Mile,No,Endure24 Leeds,Stuart Humphries,M,GBR,00:49:32.00,?,https://results.resultsbase.net/myresults.aspx?uid=8-3599-1-970772
-02/07/2022,2022,3b 5 Mile,No,Endure24 Leeds,Ralph Kidner,M,GBR,00:54:03.00,?,https://results.resultsbase.net/myresults.aspx?uid=8-3599-1-970769
-02/07/2022,2022,3b 5 Mile,No,Endure24 Leeds,Ralph Kidner,M,GBR,00:54:04.00,?,https://results.resultsbase.net/myresults.aspx?uid=8-3599-1-970763
-02/07/2022,2022,3b 5 Mile,No,Endure24 Leeds,Ralph Kidner,M,GBR,00:59:42.00,?,https://results.resultsbase.net/myresults.aspx?uid=8-3599-1-970775
-02/07/2022,2022,3b 5 Mile,No,Endure24 Leeds,Jake Lodge,M,GBR,01:05:14.00,?,https://results.resultsbase.net/myresults.aspx?uid=8-3599-1-970791
-26/06/2022,2022,3b 10 Mile,No,"Hollybank Eccup 10, Leeds",Chris Edwin,M,GBR,01:35:57.00,1,https://racebest.com/results/6vvh3?
-26/06/2022,2022,3b 10 Mile,No,"Hollybank Eccup 10, Leeds",Tim Butler,M,GBR,01:35:57.00,?,https://racebest.com/results/6vvh3?
-26/06/2022,2022,3b 10 Mile,No,"Hollybank Eccup 10, Leeds",Ralph Kidner,M,GBR,01:50:01.00,?,https://racebest.com/results/6vvh3?
-19/06/2022,2022,3b Ultra (29.5m),No,Sherwood Pines Rasselbock,Tim Butler,M,GBR,05:47:45.00,?,https://www.joggling.co.uk/Marathon-List
-12/06/2022,2022,3b 5km,Yes,Time Trial,Brady Xue,M,USA,00:20:50.00,?,https://twitter.com/hallxctf/status/1536009713976061952
-12/06/2022,2022,3b 5km,Yes,"Tutu Trot, Middletown, New Jersey",Karly Swaim,F,USA,00:27:43.00,?,
-28/05/2022,2022,3b 5km,Yes,Unknown,Ryan Himmel,M,USA,00:25:23.00,?,https://www.instagram.com/p/CeHhTezg4dh/
-23/05/2022,2022,3b Mile,Yes,Time Trial,Henry Wellenstein,M,USA,00:04:39.00,0,https://www.strava.com/activities/7136444528
-15/05/2022,2022,3b Mile,Yes,"IJA, Virtual",Koutaro Kawano,M,JPN,00:06:41.00,0,https://www.strava.com/activities/7143549125
-15/05/2022,2022,3b 10km,Yes,İstanbul'u Koşuyorum Asya Etabı (Üsküdar),Ferda Tekgül,M,TUR,01:00:02.00,?,https://event.spor.istanbul/eventresults.aspx
-15/05/2022,2022,3b Ultra (35m),No,Shires and Spires Ultra,Tim Butler,M,GBR,06:56:35.00,?,https://www.joggling.co.uk/Marathon-List
-08/05/2022,2022,3b Half Marathon,Yes,Leeds Half Marathon,Chris Edwin,M,GBR,01:20:27.00,1,
-07/05/2022,2022,3b 5km,Yes,Pymmes Parkrun,Reggie L,M,GBR,00:38:28.00,?,https://www.parkrun.org.uk/pymmes/results/503/ https://www.parkrun.org.uk/pymmes/news/2022/05/09/pymmes-parkrun-ppr-503-the-art-of-avoidance/
-05/05/2022,2022,3b Mile,Yes,"IJA, Virtual",Koutaro Kawano,M,JPN,00:06:51.00,1,https://www.strava.com/activities/7089450204
-30/04/2022,2022,3b 5km,Yes,"Claremorris Parkrun, Ireland",Malachy Kelly,M,IRL,00:26:57.00,?,https://www.facebook.com/1627994417506930/posts/pfbid0MgJYaTmHmhgwtjHcvdHLxSyGttgFK5HVHKQVvmr9n2wUUHNRRb5GHom5cVxyxXDpl/?app=fbl     https://www.parkrun.ie/claremorris/results/185/
-25/04/2022,2022,3b Mile,Yes,"IJA, Virtual",Koutaro Kawano,M,JPN,00:06:48.00,3,https://www.strava.com/activities/7036273337
-25/04/2022,2022,3b 5km,Yes,Time Trial,Koutaro Kawano,M,JPN,00:27:30.00,?,https://www.strava.com/activities/7036985894
-24/04/2022,2022,3b Marathon,Yes,Tissington Trail,Tim Butler,M,GBR,04:27:59.00,?,https://www.joggling.co.uk/Marathon-List
-23/04/2022,2022,3b Half Marathon,Yes,St. Lukes's Half Marathon,JoAnn Ireland,F,USA,02:59:26.00,?,https://runsignup.com/Race/Results/11383?customResultsPageId=55324
-18/04/2022,2022,3b Marathon,Yes,"Boston Marathon, Lincolnshire",Tim Butler,M,GBR,04:20:12.00,?,https://www.joggling.co.uk/Marathon-List
-07/04/2022,2022,3b Marathon,Yes,Badger Challenge,Tim Butler,M,GBR,05:21:08.00,?,https://www.joggling.co.uk/Marathon-List
-26/03/2022,2022,3b 5km,Yes,Marine Parade Parkrun,Scott Jenkins,M,GBR,00:19:31.00,0,
-20/03/2022,2022,3b Ultra (27.8m),No,Pierrepont Plod,Tim Butler,M,GBR,05:47:50.00,?,https://www.joggling.co.uk/Marathon-List
-12/03/2022,2022,3b 5km,Yes,Watermead Country Park Parkrun,Scott Jenkins,M,GBR,00:22:22.00,?,
-05/03/2022,2022,3b 5km,Yes,Rushmere Parkrun,Scott Jenkins,M,GBR,00:23:33.00,?,
-26/02/2022,2022,3b 5km,Yes,Portobello Parkrun,Scott Jenkins,M,GBR,00:19:34.00,0,
-19/02/2022,2022,3b 5km,Yes,Rushcliffe Parkrun,Scott Jenkins,M,GBR,00:22:49.00,?,
-13/02/2022,2022,3b 10km,Yes,Nottingham Holme Run,Scott Jenkins,M,GBR,00:41:26.00,0,
-12/02/2022,2022,3b 5km,Yes,"Dishley, Loughborough Parkrun",Scott Jenkins,M,GBR,00:26:03.00,?,
-05/02/2022,2022,3b 5km,Yes,"Dishley, Loughborough Parkrun",Scott Jenkins,M,GBR,00:30:30.00,?,
-29/01/2022,2022,3b 5km,Yes,"Dishley, Loughborough Parkrun",Scott Jenkins,M,GBR,00:22:08.00,?,
-22/01/2022,2022,3b 5km,Yes,"Dishley, Loughborough Parkrun",Scott Jenkins,M,GBR,00:24:43.00,?,
-16/01/2022,2022,3b Marathon,Yes,WTF Marathon,Tim Butler,M,GBR,04:53:50.00,?,https://www.joggling.co.uk/Marathon-List
-15/01/2022,2022,3b 5km,Yes,Rushcliffe Parkrun,Scott Jenkins,M,GBR,00:21:37.00,?,
-01/01/2022,2022,3b 5km,Yes,Gloucester City Parkrun,Jordan Evans,M,GBR,00:18:57.00,2,
-01/01/2022,2022,3b 5km,Yes,Burnham and Highbridge Parkrun,Scott Jenkins,M,GBR,00:23:32.00,?,
-25/12/2021,2021,3b 5km,Yes,Didcot Parkrun,Scott Jenkins,M,GBR,00:22:14.00,?,
-19/12/2021,2021,3b 10km,Yes,Aintree 10km,EJ Coldham,F,GBR,00:59:18.00,?,https://results.runthrough.co.uk/results.aspx?CId=16487&RId=4574&EId=2&dt=0&PageNo=4&adv=0
-19/12/2021,2021,3b 10km,Yes,Aintree 10km,JL Coldham,M,GBR,00:59:18.00,?,https://results.runthrough.co.uk/results.aspx?CId=16487&RId=4574&EId=2&dt=0&PageNo=4&adv=0
-19/12/2021,2021,3b Half Marathon,Yes,Aintree Half Marathon,Scott Jenkins,M,GBR,01:34:03.00,3,http://results.runthrough.co.uk/results.aspx?CId=16487&RId=4574&EId=5&dt=0&PageNo=1&adv=0
-18/12/2021,2021,3b 5km,Yes,"Dishley, Loughborough Parkrun",Scott Jenkins,M,GBR,00:29:54.00,?,
-04/12/2021,2021,3b 5km,Yes,Watermead Country Park Parkrun,Scott Jenkins,M,GBR,00:21:04.00,?,
-25/11/2021,2021,3b 5km,Yes,"Harrisburg Turkey Trot 5k, PA",Tim Ebersole,M,USA,00:21:02.00,?,https://falconracetiming.com/racetimes/SMT%20Turkey%20Trot%20AG%202021.htm
-20/11/2021,2021,3b 5km,Yes,"Dishley, Loughborough Parkrun",Scott Jenkins,M,GBR,00:21:23.00,?,
-07/11/2021,2021,3b Marathon,Yes,New York City Marathon,Jack Hirschowitz,M,USA,04:57:17.00,?,
-06/11/2021,2021,3b 5km,Yes,"Dishley, Loughborough Parkrun",Scott Jenkins,M,GBR,00:23:04.00,?,
-28/10/2021,2021,3b Marathon,Yes,"Time Trial, Yokohama",Koutaro Kawano,M,JPN,04:22:24.00,?,"https://www.strava.com/activities/6176836328 His first full marathon, a Japanese record"
-17/10/2021,2021,3b Marathon,Yes,Bedford Aerodrone Marathon,Tim Butler,M,GBR,04:15:15.00,?,https://www.joggling.co.uk/Marathon-List
-10/10/2021,2021,3b 10km,Yes,İstanbulu Koşuyorum Üsküdar Etabı 2021,Ferda Tekgül,M,TUR,00:52:54.00,?,https://event.spor.istanbul/eventresults.aspx
-10/10/2021,2021,3b Marathon,Yes,Chicago Marathon,Perry Romanowski,M,USA,03:49:05.00,?,https://chicago-history.r.mikatiming.com/2021/?pid=search
-10/10/2021,2021,3b Marathon,Yes,Manchester Marathon,Chris Edwin,M,GBR,03:50:15.00,15,
-03/10/2021,2021,3b Marathon,Yes,London Marathon,Ralph Kidner,M,GBR,05:51:33.00,?,https://www.runbritainrankings.com/results/results.aspx?meetingid=427704&event=Mar&venue=London&date=3-Oct-21
-02/10/2021,2021,3b 5km,Yes,"Dishley, Loughborough Parkrun",Scott Jenkins,M,GBR,00:22:15.00,?,
-26/09/2021,2021,3b Marathon,Yes,Berlin Marathon,Barak Hirschowitz,M,USA,04:25:18.00,0,https://www.bmw-berlin-marathon.com/en/impressions/statistics-and-history/results-archive/?
-26/09/2021,2021,3b Marathon,Yes,Berlin Marathon,Jack Hirschowitz,M,USA,04:59:49.00,0,https://www.bmw-berlin-marathon.com/en/impressions/statistics-and-history/results-archive/?
-25/09/2021,2021,3b 5km,Yes,"Dishley, Loughborough Parkrun",Scott Jenkins,M,GBR,00:22:32.00,?,
-19/09/2021,2021,3b Marathon,Yes,Rutland Water Marathon,Tim Butler,M,GBR,04:17:42.00,?,https://www.joggling.co.uk/Marathon-List
-19/09/2021,2021,3b Marathon,Yes,Ludwig Canal Time Trial,Peter Rupprecht,M,DEU,05:22:00.00,?,https://perujo.de/joggling-marathon-geschafft-in-5-stunden-und-22-minuten
-18/09/2021,2021,3b 5km,Yes,York Parkrun,Scott Jenkins,M,GBR,00:23:13.00,?,
-12/09/2021,2021,3b Half Marathon,Yes,"Auffahrtslauf St. Gallen Half Marathon, Switzerland",Daniel Raum,M,AUT,01:32:12.00,?,https://my.raceresult.com/163389/
-11/09/2021,2021,3b 5km,Yes,"Dishley, Loughborough Parkrun",Scott Jenkins,M,GBR,00:22:50.00,?,
-09/09/2021,2021,3b 10km,Yes,Time Trial,Gopi Devarajulu,M,IND,01:15:33.00,?,https://www.youtube.com/watch?v=1A8KjLwMQ3M
-05/09/2021,2021,3b 10km,Yes,İstanbul'u Koşuyorum Caddebostan Colour Run,Ferda Tekgül,M,TUR,00:55:22.00,?,https://event.spor.istanbul/eventresults.aspx
-04/09/2021,2021,3b 5km,Yes,"Dishley, Loughborough Parkrun",Scott Jenkins,M,GBR,00:22:16.00,?,
-28/08/2021,2021,3b 5km,Yes,Ashton Court Parkrun,Nati Tuppen,F,GBR,00:42:26.00,?,https://www.parkrun.org.uk/ashtoncourt/results/454/  https://www.parkrun.org.uk/ashtoncourt/news/2021/08/29/just-do-it-your-way-ashton-court-parkrun-454/
-21/08/2021,2021,3b 5km,Yes,Burnham and Highbridge Parkrun,Scott Jenkins,M,GBR,00:26:31.00,?,
-14/08/2021,2021,3b 5km,Yes,"Dishley, Loughborough Parkrun",Scott Jenkins,M,GBR,00:22:37.00,?,
-14/08/2021,2021,3b 5km,Yes,Eastville Parkrun,Nati Tuppen,F,GBR,00:35:30.00,?,https://www.parkrun.org.uk/eastville/news/2021/08/14/course-record-falls-and-joggling-comes-to-eastville-park/   https://www.parkrun.org.uk/eastville/results/121/
-14/08/2021,2021,3b Marathon,Yes,Horseshoe Challenge,Tim Butler,M,GBR,04:26:37.00,?,https://www.joggling.co.uk/Marathon-List
-21/07/2021,2021,3b Mile,Yes,"Harrisburg Mile Race, PA",Tim Ebersole,M,USA,00:05:47.00,?,https://falconracetiming.com/racetimes/Harrisburg%20Mile%20Overall%202021.htm
-10/07/2021,2021,3b Ultra (40m),No,Dukeries 40,Tim Butler,M,GBR,08:21:43.00,?,https://www.joggling.co.uk/Marathon-List
-19/06/2021,2021,3b Ultra (28m),No,The Halo Chesterfield,Tim Butler,M,GBR,05:50:08.00,?,https://www.joggling.co.uk/Marathon-List
-13/06/2021,2021,3b Half Marathon,Yes,"Dumb Dutchman Half Marathon, Reading, PA",Tim Ebersole,M,USA,01:36:35.00,?,https://www.pretzelcitysports.com/wp-content/uploads/2021/06/21-dd-half-results.pdf
-23/05/2021,2021,3b Marathon,Yes,Peterborough Marathon,Tim Butler,M,GBR,04:29:17.00,?,https://www.joggling.co.uk/Marathon-List
-08/05/2021,2021,3b Marathon,Yes,Colliery Canter,Tim Butler,M,GBR,05:10:02.00,?,https://www.joggling.co.uk/Marathon-List
-28/04/2021,2021,3b Mile,Yes,Time Trial,Koutaro Kawano,M,JPN,00:06:17.00,?,https://www.strava.com/activities/5204608300
-24/04/2021,2021,3b 5km,Yes,Time Trial,Toon Witters,M,BEL,00:22:19.00,15,https://www.strava.com/activities/5182010335
-04/04/2021,2021,3b 10km,Yes,N Kolay İstanbul Yarı Maratonu 2021,Ferda Tekgül,M,TUR,00:48:21.00,?,https://event.spor.istanbul/eventresults.aspx
-19/12/2020,2020,3b 5km,Yes,5km Joggling Challenge,EJ Coldham,F,GBR,00:30:20.00,?,https://www.strava.com/activities/4491314701/overview
-29/11/2020,2020,3b Marathon,Yes,Space Coast Marathon,Barak Hirschowitz,M,USA,04:46:03.00,?,https://marathonview.net/search?query=barak%20hirschowitz
-26/11/2020,2020,3b 10km,Yes,"Newport Turkey Trot 10k, PA",Tim Ebersole,M,USA,00:44:32.00,?,https://resultscui.active.com/events/2020NewportTurkeyTrot
-26/10/2020,2020,3b 10km,Yes,İstanbulu Koşuyorum Caddebostan Gazi Koşusu 2020,Ferda Tekgül,M,TUR,00:52:29.00,?,https://event.spor.istanbul/eventresults.aspx
-11/10/2020,2020,3b 10km,Yes,İstanbulu Koşuyorum Bakırköy Etabı 2020,Ferda Tekgül,M,TUR,00:50:55.00,?,https://event.spor.istanbul/eventresults.aspx
-12/09/2020,2020,3b Half Marathon,Yes,"Harrisburg Half Marathon, PA",Tim Ebersole,M,USA,01:29:56.00,0,https://falconracetiming.com/racetimes/Harrisburg%20Half%20Overall%202020.htm
-29/08/2020,2020,3b Marathon,Yes,Temple Newsam Marathon,Tim Butler,M,GBR,04:53:01.00,?,https://www.joggling.co.uk/Marathon-List
-22/08/2020,2020,3b Mile,Yes,Time Trial,Charlie Freeman,M,USA,00:05:06.00,1,https://www.tiktok.com/@cfreeman77/video/6863613020333985029
-14/07/2020,2020,3b Mile,Yes,Time Trial,Aaron Scott,M,USA,00:05:21.00,1,https://www.youtube.com/watch?v=OM97KJQIVAM
-25/04/2020,2020,3b 50km,Yes,Time Trial,John Riden,M,USA,10:49:11.00,?,https://www.strava.com/activities/3353955376
-16/04/2020,2020,5b Mile,Yes,Time Trial,Scott Jenkins,M,GBR,00:15:21.00,?,https://www.strava.com/activities/3307180189
-03/04/2020,2020,3b 5km,Yes,Time Trial,Aaron Scott,M,USA,00:17:47.00,1,https://www.youtube.com/watch?v=NYNBRc9AKHE
-08/03/2020,2020,3b Marathon,Yes,Los Angeles Marathon,Justin Delong,M,USA,04:03:25.00,?,https://www.instagram.com/p/B9n74FxlkSX/  http://results2.xacte.com/#/e/2353/searchable
-29/02/2020,2020,5b 5km,Yes,Cross Flats Parkrun,Dominic Lodge,M,GBR,00:50:00.00,?,"https://www.facebook.com/profile/100064422740314/search?q=juggle https://www.parkrun.org.uk/crossflatts/results/352/
+27/07/2023,2023,3b Mile,Yes,Time Trial,Rick Kwiatkowski,M,USA,07:48.0,?,https://www.strava.com/activities/9534592553
+26/07/2023,2023,3b Marathon,Yes,Great Barrow Challenge Day 5,Tim Butler,M,GBR,41:09.0,?,https://www.joggling.co.uk/Marathon-List
+24/07/2023,2023,3b 5km,Yes,"Deseret News Marathon 5k, Utah",David Tate,M,USA,26:26.0,0,https://twitter.com/dren_braves/status/1683494655470518278?t=ctWFUgmkvj__L-g09rS9MA&s=19      https://www.brooksee.com/des/results?sort=&race=167024&date=&event=5K&gender=&division=&search=Tate&loc_168380=&page_168380=1&size_168380=25&loc_168381=&page_168381=1&size_168381=25&loc_168382=&page_168382=1&size_168382=25&loc_168383=&page_168383=1&size_168383=25&loc_168384=&page_168384=1&size_168384=25
+22/07/2023,2023,3b 5km,Yes,Holyrood Parkrun ,James McDiarmid,M,GBR,20:11.0,0,https://www.parkrun.org.uk/holyrood/results/48/?utm_medium=email&utm_source=resultsemail&utm_campaign=systememail
+22/07/2023,2023,3b 5km,Yes,Aberystwyth Parkrun,Derrick Adams,M,GBR,26:16.0,?,https://www.parkrun.org.uk/aberystwyth/results/497/ Reports of Derrick joggling on Facebook this week
+22/07/2023,2023,3b 5km,Yes,Jubilee Parkrun,Scott Jenkins,M,GBR,28:06.0,0,https://www.strava.com/activities/9498231178  https://www.parkrun.org.uk/jubilee/results/110/
+16/07/2023,2023,3b Half Marathon,Yes,Ilkley Half Marathon,Chris Edwin,M,GBR,22:18.0,0,https://www.sportstimingsolutions.co.uk/rd.php?id=484
+16/07/2023,2023,3b Half Marathon,Yes,Ilkley Half Marathon,Scott Jenkins,M,GBR,44:28.0,0,https://www.sportstimingsolutions.co.uk/rd.php?id=484
+15/07/2023,2023,3b 5km,Yes,Holyrood Parkrun,James McDiarmid,M,GBR,21:09.0,2,
+15/07/2023,2023,3b 5km,Yes,Huddersfield Parkrun,Jake Lodge,M,GBR,22:12.0,4,https://www.parkrun.org.uk/huddersfield/results/543/ https://www.strava.com/activities/9454005319
+15/07/2023,2023,3b 5km,Yes,Roberts Park Parkrun,Scott Jenkins,M,GBR,24:39.0,2,https://www.parkrun.org.uk/robertspark/results/89/ https://www.strava.com/activities/9454347891
+15/07/2023,2023,3b 5km,Yes,Roberts Park Parkrun,Chris Edwin,M,GBR,24:40.0,0,https://www.parkrun.org.uk/robertspark/results/89/ https://www.strava.com/activities/9453836097
+10/07/2023,2023,3b Mile,Yes,Time Trial,Tim Ebersole,M,USA,06:11.0,?,https://www.strava.com/activities/9426849905
+08/07/2023,2023,3b 5km,Yes,Stamford Park Parkrun,Jake Lodge,M,GBR,21:38.0,?,https://www.parkrun.org.uk/stamfordpark/results/341/  https://www.strava.com/activities/9409921616
+08/07/2023,2023,3b 5km,Yes,St Andrews Parkrun,Scott Jenkins,M,GBR,22:19.0,0,https://www.parkrun.org.uk/standrews/results/489/
+07/07/2023,2023,3b 10km,Yes,"SoJo Glow Run, South Jordan, Utah",David Tate,M,USA,59:59.0,?,https://twitter.com/dren_braves/status/1677692169803673600
+01/07/2023,2023,3b 5km,Yes,Polkemmet Country Parkrun,Scott Jenkins,M,GBR,23:18.0,0,https://www.parkrun.org.uk/polkemmetcountry/results/137/
+01/07/2023,2023,3b 5km,Yes,FSM China 5k,Dana Lee Ling,M,FSM,56:57.0,1,https://www.strava.com/activities/9364589789 https://www.facebook.com/100091873519711/posts/pfbid02xXwXYu6tfDkMg1nxegsv8UwobrTHehg6BjDce9DrsEsebX9qbjhPtWRQ9S2ZL9H4l/?app=fbl 
+24/06/2023,2023,3b 5km,Yes,Holyrood Parkrun,James McDiarmid,M,GBR,21:38.0,?,https://www.parkrun.org.uk/holyrood/results/44/
+18/06/2023,2023,3b 50km,Yes,Trackathon,Tim Butler,M,GBR,58:05.0,?,https://www.joggling.co.uk/Marathon-List
+17/06/2023,2023,3b 5km,Yes,Milano Nord Parkrun,Scott Jenkins,M,GBR,28:57.0,0,https://www.strava.com/activities/9280386127  https://www.parkrun.it/milanonord/results/271/
+16/06/2023,2023,3b Half Marathon,Yes,"Nacht Van Vlaanderen Half Marathon, Belgium",Toon Witters,M,BEL,53:11.0,?,https://www.strava.com/activities/9278465811 https://www.focus-wtv.be/nieuws/toon-loopt-halve-marathon-op-blote-voeten-en-al-jonglerend
+10/06/2023,2023,3b 5km,Yes,Holyrood Parkrun,James McDiarmid,M,GBR,22:19.0,6,https://www.parkrun.org.uk/holyrood/results/42/
+10/06/2023,2023,3b 5km,Yes,Dinton Pastures Parkrun,Stuart Humphries,M,GBR,27:22.0,?,https://www.parkrun.org.uk/dintonpastures/results/189/
+04/06/2023,2023,3b Half Marathon,Yes,Cork Half Marathon,Scott Jenkins,M,GBR,47:39.0,0,https://www.strava.com/activities/9200562937  https://www.corkathletics.org/latest-results/2023/434-june/2907-cork-city-half-marathon-results-june-2023.html
+04/06/2023,2023,3b Ultra (28.5m),No,Butterfly Run,Tim Butler,M,GBR,39:52.0,?,https://www.joggling.co.uk/Marathon-List
+28/05/2023,2023,3b Half Marathon,Yes,Edinburgh Half Marathon,Scott Jenkins,M,GBR,27:48.0,2,https://www.strava.com/activities/9154792920
+27/05/2023,2023,3b 5km,Yes,Ottawa,Michael-Lucien Bergeron,M,CAN,17:24.0,?,https://www.strava.com/activities/9152812476
+27/05/2023,2023,3b 5km,Yes,Dunfermline Parkrun,Scott Jenkins,M,GBR,20:44.0,0,https://www.parkrun.org.uk/dunfermline/results/311  https://www.strava.com/activities/9148516853
+26/05/2023,2023,3b 3km,Yes,Glasgow Green,Scott Jenkins,M,GBR,10:21.0,0,https://www.strava.com/activities/9143369867
+20/05/2023,2023,3b 5km,Yes,Meadowmill Parkrun,Scott Jenkins,M,GBR,20:56.0,3,https://www.parkrun.org.uk/meadowmill/results/135  https://www.strava.com/activities/9104572768
+20/05/2023,2023,3b 5km,Yes,Aberystwyth Parkrun,Derrick Adams,M,GBR,26:36.0,0,https://www.parkrun.org.uk/aberystwyth/results/488/  Twitter post (Found by Chris E)
+14/05/2023,2023,3b 5km,Yes,Time Trial,Toon Witters,M,BEL,23:41.0,1,"https://www.strava.com/activities/9068289058, barefoot"
+14/05/2023,2023,3c 10km,Yes,Blackpool,JL Coldham,M,GBR,07:14.0,?,Clubs. https://www.strava.com/activities/9069210875  https://www.facebook.com/526246301/videos/1519666768437135/  https://www.sportstimingsolutions.co.uk/rcd.php?id=472&bib=1252
+14/05/2023,2023,3b Marathon,Yes,Leeds Marathon,Chris Edwin,M,GBR,09:13.0,1,https://www.strava.com/activities/9069308254
+14/05/2023,2023,3b Marathon,Yes,Leeds Marathon,Tim Butler,M,GBR,41:11.0,?,https://www.strava.com/activities/9071024334
+13/05/2023,2023,3b 10km,Yes,"Penicuik, Scotland",Scott Jenkins,M,GBR,40:28.0,0,https://www.strava.com/activities/9062494677
+07/05/2023,2023,3b Marathon,Yes,Lincoln Marathon,Trevor McQuay,M,USA,30:42.0,?,https://www.mtecresults.com/runner/show?race=14950&rid=554 https://www.strava.com/activities/9029190962
+06/05/2023,2023,3b 5km,Yes,Holyrood Parkrun,Scott Jenkins,M,GBR,24:18.0,2,https://www.parkrun.org.uk/holyrood/results/38  https://www.strava.com/activities/9020536793
+23/04/2023,2023,3b Half Marathon,Yes,St. Luke's Half Marathon,Scott Boehret,M,USA,48:43.0,1,https://runsignup.com/Race/Results/11383/?customResultsPageId=61903&segmentId=406332&row=261
+23/04/2023,2023,3b Half Marathon,Yes,Rock n Roll Nashville,John Dombach,M,USA,56:47.0,6,https://www.runrocknroll.com/nashville-results   https://www.instagram.com/p/CrUOvmqpPuF/
+22/04/2023,2023,3b 5km,Yes,Tollcross Parkrun,Scott Jenkins,M,GBR,20:57.0,0,https://www.strava.com/activities/8935351158
+22/04/2023,2023,3b 10km,Yes,"Richmond, VA",Jonathan Austin,M,USA,51:15.0,0,Email exchange
+22/04/2023,2023,3b 10km,Yes,"SoJo Earth Day 10k, Utah",David Tate,M,USA,55:24.0,0,https://results.raceroster.com/en-US/results/detail/fk5f3msqrvvbd33n    https://twitter.com/dren_braves/status/1649826780231110656?t=gCRH4mIKsuIswg-kz8Wp1A&s=19
+16/04/2023,2023,3b Marathon,Yes,Manchester Marathon,Chris Edwin,M,GBR,10:30.0,0,
+15/04/2023,2023,3b 5km,Yes,Vogrie Parkrun,Scott Jenkins,M,GBR,20:33.0,0,https://www.strava.com/activities/8893490771
+08/04/2023,2023,3b 5km,Yes,Edinburgh Parkrun,Scott Jenkins,M,GBR,20:52.0,1,https://www.strava.com/activities/8852459895
+02/04/2023,2023,3b 5km,Yes,Southampton 5km,Kevin Sawers,M,GBR,32:04.0,?,https://www.strava.com/activities/8817698457   https://dbmaxresults.co.uk/results.aspx?CId=16421&RId=405&EId=6&dt=0&PageNo=2&adv=0
+01/04/2023,2023,3b 5km,Yes,Meadowmill Parkrun,Scott Jenkins,M,GBR,20:18.0,0,https://www.strava.com/activities/8811969159
+01/04/2023,2023,3b 5km,Yes,Preston Park Parkrun,Jake Lodge,M,GBR,23:21.0,?,https://www.parkrun.org.uk/prestonpark/results/440/  https://www.strava.com/activities/8814301066
+25/03/2023,2023,3b 5km,Yes,Livingston Parkrun,Scott Jenkins,M,GBR,27:59.0,0,https://www.strava.com/activities/8773238448
+25/03/2023,2023,3b Ultra (27.5m),No,Great British Seaside Challenge,Tim Butler,M,GBR,26:01.0,?,https://www.joggling.co.uk/Marathon-List
+19/03/2023,2023,3b Half Marathon,Yes,Wigan Half Marathon,Chris Edwin,M,GBR,22:19.0,0,
+18/03/2023,2023,3b 5km,Yes,Oriam Parkrun,Scott Jenkins,M,GBR,20:10.0,0,https://www.strava.com/activities/8733520825
+18/03/2023,2023,3b 5km,Yes,Nobles Parkrun,Jake Lodge,M,GBR,22:34.0,?,https://www.parkrun.org.uk/nobles/results/224/  https://www.parkrun.org.uk/nobles/news/2023/03/21/nobles-parkrun-event-224/   https://www.instagram.com/p/Cp7aQ-iDjkc/
+18/03/2023,2023,3b 5km,Yes,"SoJo Gold Rush Race 5k, Utah",David Tate,M,USA,27:12.0,0,https://results.raceroster.com/en-US/results/detail/q2ujswhv74k37m4v     https://twitter.com/dren_braves/status/1638301785600425985?t=6CoSh0lgpz_2gcWnjjedGQ&s=19
+11/03/2023,2023,3b 5km,Yes,Torvean Parkrun,Scott Jenkins,M,GBR,26:21.0,0,https://www.strava.com/activities/8695029181
+07/03/2023,2023,3b Marathon,Yes,Big Bear Elephant Run,Tim Butler,M,GBR,58:04.0,?,https://www.joggling.co.uk/Marathon-List
+05/03/2023,2023,3b Marathon,Yes,Tokyo Marathon,Barak Hirschowitz,M,USA,10:00.0,0,https://www.marathon.tokyo/2023/result/detail.php
+05/03/2023,2023,3b Marathon,Yes,Tokyo Marathon,Jack Hirschowitz,M,USA,55:10.0,0,https://www.marathon.tokyo/2023/result/detail.php
+04/03/2023,2023,3b 5km,Yes,"Queen's, Glasgow Parkrun",Scott Jenkins,M,GBR,22:41.0,0,https://www.strava.com/activities/8656799309
+22/02/2023,2023,3b Half Marathon,Yes,Time Trial,Jake Lodge,M,GBR,45:28.0,?,https://www.strava.com/activities/8602663011
+19/02/2023,2023,3b 5km,Yes,Roberts Park Parkrun,Chris Edwin,M,GBR,19:12.0,1,https://www.parkrun.org.uk/robertspark/results/19/      https://www.facebook.com/108529600921199/posts/pfbid0xiw65sANFevSWGv3avyQoS8v81v9Vyvz83nWbR9Zx7TBRMxYKAk6Xc4CW6C9UAoTl/?app=fbl
+19/02/2023,2023,3b 5km,Yes,Roberts Park Parkrun,Ralph Kidner,M,GBR,34:13.0,?,https://www.parkrun.org.uk/robertspark/results/19/      https://www.facebook.com/108529600921199/posts/pfbid0xiw65sANFevSWGv3avyQoS8v81v9Vyvz83nWbR9Zx7TBRMxYKAk6Xc4CW6C9UAoTl/?app=fbl
+19/02/2023,2023,3b Marathon,Yes,Bingley,Tim Butler,M,GBR,46:15.0,?,https://www.joggling.co.uk/Marathon-List
+12/02/2023,2023,3b Marathon,Yes,"Brandon Park, Suffolk",Tim Butler,M,GBR,51:10.0,?,https://www.joggling.co.uk/Marathon-List
+11/02/2023,2023,3b 5km,Yes,Vogrie Parkrun,Scott Jenkins,M,GBR,24:48.0,1,https://www.strava.com/activities/8541362997
+10/02/2023,2023,3b 5km,Yes,Park im. Jana Pawla II Parkrun,Kacper Suchora,M,POL,27:06.0,?,
+04/02/2023,2023,3b 5km,Yes,Hay Lodge Parkrun,Scott Jenkins,M,GBR,20:47.0,0,https://www.strava.com/activities/8502123456
+28/01/2023,2023,3b 5km,Yes,Falkirk Parkrun,Scott Jenkins,M,GBR,23:29.0,1,https://www.strava.com/activities/8464216907
+28/01/2023,2023,3b 5km,Yes,Chevin Forest Parkrun,Jake Lodge,M,GBR,24:48.0,?,https://www.parkrun.org.uk/chevinforest/results/73/  https://www.strava.com/activities/8464067384
+27/01/2023,2023,3b Marathon,Yes,Knaresmire Edge Rewind,Tim Butler,M,GBR,46:55.0,?,https://www.joggling.co.uk/Marathon-List
+21/01/2023,2023,3b 5km,Yes,Lochend Woods Parkrun,Scott Jenkins,M,GBR,20:58.0,0,https://www.strava.com/activities/8426310028
+14/01/2023,2023,3b 5km,Yes,Brighouse Parkrun,Jake Lodge,M,GBR,22:21.0,4,https://www.strava.com/activities/8390331189  https://www.parkrun.org.uk/brighouse/results/231/
+07/01/2023,2023,3b 5km,Yes,Pobalscoil Na Trionoide Parkrun,Brian Linehan,M,IRL,23:25.0,?,https://www.parkrun.ie/pobalscoilnatrionoide/results/44/   https://www.facebook.com/profile/100067922504955/search/?q=juggling
+30/12/2022,2022,3b Marathon,Yes,Bridlington,Tim Butler,M,GBR,44:55.0,?,https://www.joggling.co.uk/Marathon-List
+24/12/2022,2022,3b 5km,Yes,Burnham and Highbridge Parkrun,Scott Jenkins,M,GBR,23:47.0,0,https://www.strava.com/activities/8284952061
+17/12/2022,2022,3b Marathon,Yes,Maramile,Tim Butler,M,GBR,18:29.0,?,https://www.joggling.co.uk/Marathon-List
+03/12/2022,2022,3b 10km,Yes,Forchheimer Nikolauslauf,Peter Meyer,M,DEU,59:43.0,4,https://www.hdsports.at/laufen/forchheimer-nikolauslauf  http://home.mnet-online.de/joggling/aboutme_d.htm
+26/11/2022,2022,3b 5km,Yes,Holyrood Parkrun,Scott Jenkins,M,GBR,23:56.0,?,https://www.strava.com/activities/8170151768
+20/11/2022,2022,3b Marathon,Yes,Maravan,Tim Butler,M,GBR,27:07.0,?,https://www.joggling.co.uk/Marathon-List
+19/11/2022,2022,3b 5km,Yes,Kirkcaldy Parkrun,Scott Jenkins,M,GBR,21:47.0,0,https://www.strava.com/activities/8138686226
+19/11/2022,2022,3b 5km,Yes,Prospet Parkrun,Stuart Humphries,M,GBR,25:40.0,?,https://www.facebook.com/watch/?v=1163098037643456   https://www.parkrun.org.uk/prospect/results/154/
+06/11/2022,2022,3b Marathon,Yes,New York City Marathon,Barak Hirschowitz,M,USA,51:10.0,?,https://results.nyrr.org/event/M2022/finishers#search=Barak%2520Hirschowitz
+06/11/2022,2022,3b Marathon,Yes,New York City Marathon,Jack Hirschowitz,M,USA,11:39.0,?,https://results.nyrr.org/event/M2022/finishers#page=1&search=Jack%2520Hirschowitz
+05/11/2022,2022,3b 5km,Yes,University of Stirling Parkrun,Scott Jenkins,M,GBR,22:54.0,0,
+05/11/2022,2022,3b 10km,Yes,Time Trial,Henry Wellenstein,M,USA,33:34.0,?,https://www.strava.com/activities/8074621672
+16/10/2022,2022,3b Marathon,Yes,Yorkshire Marathon,Tim Butler,M,GBR,24:32.0,?,https://www.joggling.co.uk/Marathon-List
+15/10/2022,2022,3b 5km,Yes,Livingston Parkrun,Scott Jenkins,M,GBR,24:19.0,?,https://www.strava.com/activities/7965340687
+09/10/2022,2022,3b Marathon,Yes,Chicago Marathon,Perry Romanowski,M,USA,59:49.0,?,https://chicago-history.r.mikatiming.com/2021/?pid=search
+09/10/2022,2022,3b Marathon,Yes,Chicago Marathon,Barak Hirschowitz,M,USA,42:47.0,?,https://results.chicagomarathon.com/2022/?pid=search&pidp=start
+09/10/2022,2022,3b Marathon,Yes,Chicago Marathon,Jack Hirschowitz,M,USA,03:24.0,?,https://results.chicagomarathon.com/2022/?pid=search&pidp=start
+08/10/2022,2022,3b 5km,Yes,Pontypool Parkrun,Jake Lodge,M,GBR,23:21.0,?,https://www.strava.com/activities/7928899111  https://www.parkrun.org.uk/pontypool/results/372/
+02/10/2022,2022,3b Marathon,Yes,London Marathon,Barak Hirschowitz,M,USA,15:35.0,?,https://results.tcslondonmarathon.com/2022/?pid=search
+02/10/2022,2022,3b Marathon,Yes,Ruddy Rothwell Cakeathon,Tim Butler,M,GBR,53:16.0,?,https://www.joggling.co.uk/Marathon-List
+02/10/2022,2022,3b Marathon,Yes,London Marathon,Jack Hirschowitz,M,USA,03:53.0,?,https://results.tcslondonmarathon.com/2022/?pid=search
+01/10/2022,2022,3b 5km,Yes,Oriam Parkrun,Scott Jenkins,M,GBR,22:13.0,0,https://www.strava.com/activities/7893388827
+25/09/2022,2022,3b Marathon,Yes,Heartland Marathon,Trevor McQuay,M,USA,57:48.0,?,https://omaharun.org/wp-content/uploads/2022/10/ORCNewsletter_Fall-2022.pdf
+25/09/2022,2022,3b Marathon,Yes,Rutland Water Marathon,Tim Butler,M,GBR,33:19.0,?,https://www.joggling.co.uk/Marathon-List
+24/09/2022,2022,3b 5km,Yes,Vogrie Parkrun,Scott Jenkins,M,GBR,22:22.0,?,https://www.strava.com/activities/7858042399
+24/09/2022,2022,3b 5km,Yes,Marple Parkrun,Jake Lodge,M,GBR,27:33.0,?,https://www.parkrun.org.uk/marple/results/475/ https://www.strava.com/activities/7857853981
+17/09/2022,2022,3b Half Marathon,Yes,Oslo Half Marathon,Jake Lodge,M,GBR,49:18.0,?,https://www.strava.com/activities/7822440712  https://live.ultimate.dk/desktop/front/index.php?eventid=5388&ignoreuseragent=true
+11/09/2022,2022,3b Half Marathon,Yes,"Harrisburg Half Marathon, PA",Tim Ebersole,M,USA,36:28.0,?,https://runsignup.com/Race/Results/15430#resultSetId-336858;perpage:100
+10/09/2022,2022,3b 5km,Yes,Edinburgh Parkrun,Scott Jenkins,M,GBR,23:48.0,?,
+27/08/2022,2022,3b Ultra (49.6m),No,12 Hour Back to School Run,Tim Butler,M,GBR,40:32.0,?,https://www.joggling.co.uk/Marathon-List
+20/08/2022,2022,3b 5km,Yes,Glen River Parkrun,Brian Linehan,M,IRL,24:16.0,?,https://www.parkrun.ie/glenriver/results/119/    https://www.instagram.com/p/Che91wjjOL1/
+09/08/2022,2022,3b Mile,Yes,Ramsbottom Summer Mile,Jake Lodge,M,GBR,06:24.0,?,https://my.raceresult.com/214433/results  https://www.strava.com/activities/7610827072
+08/08/2022,2022,3b 5km,Yes,"North Beach Parkrun, Durban, South Africa",Gavin Levenstein,M,ZAF,22:33.0,?,https://www.parkrun.co.za/northbeach/results/409/
+05/08/2022,2022,3b 50km,Yes,Double Blinkathon,Tim Butler,M,GBR,34:59.0,?,https://www.joggling.co.uk/Marathon-List
+30/07/2022,2022,3b 5km,Yes,Irchester Country Parkrun,Scott Jenkins,M,GBR,23:43.0,?,
+28/07/2022,2022,3b 5km,Yes,Time Trial,John Baker,M,USA,16:56.0,?,https://www.instagram.com/p/CgiOHBcBGU6/
+23/07/2022,2022,3b 5km,Yes,Newent Parkrun,Scott Jenkins,M,GBR,25:43.0,2,
+23/07/2022,2022,3b Ultra (28m),No,Conquer the Castle,Tim Butler,M,GBR,27:25.0,?,https://www.joggling.co.uk/Marathon-List
+10/07/2022,2022,3b 10km,Yes,Time Trial,Michael-Lucien Bergeron,M,CAN,34:47.0,?,
+10/07/2022,2022,3b Half Marathon,Yes,Ilkely Half Marathon,Chris Edwin,M,GBR,41:40.0,0,
+09/07/2022,2022,3b 5km,Yes,Abingdon Parkrun,Scott Jenkins,M,GBR,26:58.0,?,
+03/07/2022,2022,3b 5 Mile,No,Endure24 Leeds,Jordan Evans,M,GBR,35:33.0,?,https://results.resultsbase.net/myresults.aspx?uid=8-3599-1-970782
+03/07/2022,2022,3b 5 Mile,No,Endure24 Leeds,Jordan Evans,M,GBR,35:35.0,?,https://results.resultsbase.net/myresults.aspx?uid=8-3599-1-970787
+03/07/2022,2022,3b 5 Mile,No,Endure24 Leeds,Jake Lodge,M,GBR,43:52.0,?,https://results.resultsbase.net/myresults.aspx?uid=8-3599-1-970785
+03/07/2022,2022,3b 5 Mile,No,Endure24 Leeds,Jake Lodge,M,GBR,46:18.0,?,https://results.resultsbase.net/myresults.aspx?uid=8-3599-1-970788
+03/07/2022,2022,3b 5 Mile,No,Endure24 Leeds,Jake Lodge,M,GBR,54:03.0,?,https://results.resultsbase.net/myresults.aspx?uid=8-3599-1-970780
+03/07/2022,2022,3b 5 Mile,No,Endure24 Leeds,Ralph Kidner,M,GBR,56:28.0,?,https://results.resultsbase.net/myresults.aspx?uid=8-3599-1-970781
+03/07/2022,2022,3b 5 Mile,No,Endure24 Leeds,Stuart Humphries,M,GBR,58:42.0,?,https://results.resultsbase.net/myresults.aspx?uid=8-3599-1-970778
+03/07/2022,2022,3b 5 Mile,No,Endure24 Leeds,Dominic Lodge,M,GBR,59:21.0,?,https://results.resultsbase.net/myresults.aspx?uid=8-3599-1-970779
+03/07/2022,2022,3b 5 Mile,No,Endure24 Leeds,Dominic Lodge,M,GBR,59:57.0,?,https://results.resultsbase.net/myresults.aspx?uid=8-3599-1-970784
+03/07/2022,2022,3b 5 Mile,No,Endure24 Leeds,Ralph Kidner,M,GBR,59:58.0,?,https://results.resultsbase.net/myresults.aspx?uid=8-3599-1-970786
+03/07/2022,2022,3b 5 Mile,No,Endure24 Leeds,Scott Jenkins,M,GBR,01:48.0,?,https://results.resultsbase.net/myresults.aspx?uid=8-3599-1-970783
+03/07/2022,2022,3b 5 Mile,No,Endure24 Leeds,Scott Jenkins,M,GBR,02:28.0,?,https://results.resultsbase.net/myresults.aspx?uid=8-3599-1-970777
+02/07/2022,2022,3b 5km,Yes,York Parkrun,Jordan Evans,M,GBR,20:59.0,?,https://www.parkrun.org.uk/york/results/417/
+02/07/2022,2022,3b 5km,Yes,York Parkrun,Dominic Lodge,M,GBR,25:22.0,?,https://www.parkrun.org.uk/york/results/417/
+02/07/2022,2022,3b 5km,Yes,York Parkrun,Jake Lodge,M,GBR,27:20.0,?,https://www.parkrun.org.uk/york/results/417/
+02/07/2022,2022,3b 5km,Yes,York Parkrun,Scott Jenkins,M,GBR,31:57.0,0,https://www.parkrun.org.uk/york/results/417/
+02/07/2022,2022,3b 5 Mile,No,Endure24 Leeds,Jordan Evans,M,GBR,32:36.0,?,https://results.resultsbase.net/myresults.aspx?uid=8-3599-1-970764
+02/07/2022,2022,3b 5 Mile,No,Endure24 Leeds,Jordan Evans,M,GBR,33:47.0,?,https://results.resultsbase.net/myresults.aspx?uid=8-3599-1-970770
+02/07/2022,2022,3b 5 Mile,No,Endure24 Leeds,Jordan Evans,M,GBR,34:52.0,?,https://results.resultsbase.net/myresults.aspx?uid=8-3599-1-970776
+02/07/2022,2022,3b 5 Mile,No,Endure24 Leeds,Dominic Lodge,M,GBR,35:32.0,?,https://results.resultsbase.net/myresults.aspx?uid=8-3599-1-970767
+02/07/2022,2022,3b 5 Mile,No,Endure24 Leeds,Jordan Evans,M,GBR,36:29.0,?,https://results.resultsbase.net/myresults.aspx?uid=8-3599-1-970790
+02/07/2022,2022,3b 5 Mile,No,Endure24 Leeds,Dominic Lodge,M,GBR,37:19.0,?,https://results.resultsbase.net/myresults.aspx?uid=8-3599-1-970773
+02/07/2022,2022,3b 5 Mile,No,Endure24 Leeds,Dominic Lodge,M,GBR,38:32.0,?,https://results.resultsbase.net/myresults.aspx?uid=8-3599-1-970761
+02/07/2022,2022,3b 5 Mile,No,Endure24 Leeds,Scott Jenkins,M,GBR,40:10.0,?,https://results.resultsbase.net/myresults.aspx?uid=8-3599-1-970765
+02/07/2022,2022,3b 5 Mile,No,Endure24 Leeds,Jake Lodge,M,GBR,41:51.0,?,https://results.resultsbase.net/myresults.aspx?uid=8-3599-1-970762
+02/07/2022,2022,3b 5 Mile,No,Endure24 Leeds,Scott Jenkins,M,GBR,43:01.0,?,https://results.resultsbase.net/myresults.aspx?uid=8-3599-1-970771
+02/07/2022,2022,3b 5 Mile,No,Endure24 Leeds,Jake Lodge,M,GBR,43:12.0,?,https://results.resultsbase.net/myresults.aspx?uid=8-3599-1-970768
+02/07/2022,2022,3b 5 Mile,No,Endure24 Leeds,Jake Lodge,M,GBR,44:53.0,?,https://results.resultsbase.net/myresults.aspx?uid=8-3599-1-970774
+02/07/2022,2022,3b 5 Mile,No,Endure24 Leeds,Stuart Humphries,M,GBR,48:20.0,?,https://results.resultsbase.net/myresults.aspx?uid=8-3599-1-970766
+02/07/2022,2022,3b 5 Mile,No,Endure24 Leeds,Scott Jenkins,M,GBR,49:11.0,?,https://results.resultsbase.net/myresults.aspx?uid=8-3599-1-970789
+02/07/2022,2022,3b 5 Mile,No,Endure24 Leeds,Stuart Humphries,M,GBR,49:32.0,?,https://results.resultsbase.net/myresults.aspx?uid=8-3599-1-970772
+02/07/2022,2022,3b 5 Mile,No,Endure24 Leeds,Ralph Kidner,M,GBR,54:03.0,?,https://results.resultsbase.net/myresults.aspx?uid=8-3599-1-970769
+02/07/2022,2022,3b 5 Mile,No,Endure24 Leeds,Ralph Kidner,M,GBR,54:04.0,?,https://results.resultsbase.net/myresults.aspx?uid=8-3599-1-970763
+02/07/2022,2022,3b 5 Mile,No,Endure24 Leeds,Ralph Kidner,M,GBR,59:42.0,?,https://results.resultsbase.net/myresults.aspx?uid=8-3599-1-970775
+02/07/2022,2022,3b 5 Mile,No,Endure24 Leeds,Jake Lodge,M,GBR,05:14.0,?,https://results.resultsbase.net/myresults.aspx?uid=8-3599-1-970791
+26/06/2022,2022,3b 10 Mile,No,"Hollybank Eccup 10, Leeds",Chris Edwin,M,GBR,35:57.0,1,https://racebest.com/results/6vvh3?
+26/06/2022,2022,3b 10 Mile,No,"Hollybank Eccup 10, Leeds",Tim Butler,M,GBR,35:57.0,?,https://racebest.com/results/6vvh3?
+26/06/2022,2022,3b 10 Mile,No,"Hollybank Eccup 10, Leeds",Ralph Kidner,M,GBR,50:01.0,?,https://racebest.com/results/6vvh3?
+19/06/2022,2022,3b Ultra (29.5m),No,Sherwood Pines Rasselbock,Tim Butler,M,GBR,47:45.0,?,https://www.joggling.co.uk/Marathon-List
+12/06/2022,2022,3b 5km,Yes,Time Trial,Brady Xue,M,USA,20:50.0,?,https://twitter.com/hallxctf/status/1536009713976061952
+12/06/2022,2022,3b 5km,Yes,"Tutu Trot, Middletown, New Jersey",Karly Swaim,F,USA,27:43.0,?,
+28/05/2022,2022,3b 5km,Yes,Unknown,Ryan Himmel,M,USA,25:23.0,?,https://www.instagram.com/p/CeHhTezg4dh/
+23/05/2022,2022,3b Mile,Yes,Time Trial,Henry Wellenstein,M,USA,04:39.0,0,https://www.strava.com/activities/7136444528
+15/05/2022,2022,3b 10km,Yes,İstanbul'u Koşuyorum Asya Etabı (Üsküdar),Ferda Tekgül,M,TUR,00:02.0,?,https://event.spor.istanbul/eventresults.aspx
+15/05/2022,2022,3b Ultra (35m),No,Shires and Spires Ultra,Tim Butler,M,GBR,56:35.0,?,https://www.joggling.co.uk/Marathon-List
+08/05/2022,2022,3b Half Marathon,Yes,Leeds Half Marathon,Chris Edwin,M,GBR,20:27.0,1,
+07/05/2022,2022,3b 5km,Yes,Pymmes Parkrun,Reggie L,M,GBR,38:28.0,?,https://www.parkrun.org.uk/pymmes/results/503/ https://www.parkrun.org.uk/pymmes/news/2022/05/09/pymmes-parkrun-ppr-503-the-art-of-avoidance/
+30/04/2022,2022,3b 5km,Yes,"Claremorris Parkrun, Ireland",Malachy Kelly,M,IRL,26:57.0,?,https://www.facebook.com/1627994417506930/posts/pfbid0MgJYaTmHmhgwtjHcvdHLxSyGttgFK5HVHKQVvmr9n2wUUHNRRb5GHom5cVxyxXDpl/?app=fbl     https://www.parkrun.ie/claremorris/results/185/
+25/04/2022,2022,3b 5km,Yes,Time Trial,Koutaro Kawano,M,JPN,27:30.0,?,https://www.strava.com/activities/7036985894
+24/04/2022,2022,3b Marathon,Yes,Tissington Trail,Tim Butler,M,GBR,27:59.0,?,https://www.joggling.co.uk/Marathon-List
+23/04/2022,2022,3b Half Marathon,Yes,St. Lukes's Half Marathon,JoAnn Ireland,F,USA,59:26.0,?,https://runsignup.com/Race/Results/11383?customResultsPageId=55324
+18/04/2022,2022,3b Marathon,Yes,"Boston Marathon, Lincolnshire",Tim Butler,M,GBR,20:12.0,?,https://www.joggling.co.uk/Marathon-List
+07/04/2022,2022,3b Marathon,Yes,Badger Challenge,Tim Butler,M,GBR,21:08.0,?,https://www.joggling.co.uk/Marathon-List
+26/03/2022,2022,3b 5km,Yes,Marine Parade Parkrun,Scott Jenkins,M,GBR,19:31.0,0,
+20/03/2022,2022,3b Ultra (27.8m),No,Pierrepont Plod,Tim Butler,M,GBR,47:50.0,?,https://www.joggling.co.uk/Marathon-List
+12/03/2022,2022,3b 5km,Yes,Watermead Country Park Parkrun,Scott Jenkins,M,GBR,22:22.0,?,
+05/03/2022,2022,3b 5km,Yes,Rushmere Parkrun,Scott Jenkins,M,GBR,23:33.0,?,
+26/02/2022,2022,3b 5km,Yes,Portobello Parkrun,Scott Jenkins,M,GBR,19:34.0,0,
+19/02/2022,2022,3b 5km,Yes,Rushcliffe Parkrun,Scott Jenkins,M,GBR,22:49.0,?,
+13/02/2022,2022,3b 10km,Yes,Nottingham Holme Run,Scott Jenkins,M,GBR,41:26.0,0,
+12/02/2022,2022,3b 5km,Yes,"Dishley, Loughborough Parkrun",Scott Jenkins,M,GBR,26:03.0,?,
+05/02/2022,2022,3b 5km,Yes,"Dishley, Loughborough Parkrun",Scott Jenkins,M,GBR,30:30.0,?,
+29/01/2022,2022,3b 5km,Yes,"Dishley, Loughborough Parkrun",Scott Jenkins,M,GBR,22:08.0,?,
+22/01/2022,2022,3b 5km,Yes,"Dishley, Loughborough Parkrun",Scott Jenkins,M,GBR,24:43.0,?,
+16/01/2022,2022,3b Marathon,Yes,WTF Marathon,Tim Butler,M,GBR,53:50.0,?,https://www.joggling.co.uk/Marathon-List
+15/01/2022,2022,3b 5km,Yes,Rushcliffe Parkrun,Scott Jenkins,M,GBR,21:37.0,?,
+01/01/2022,2022,3b 5km,Yes,Gloucester City Parkrun,Jordan Evans,M,GBR,18:57.0,2,
+01/01/2022,2022,3b 5km,Yes,Burnham and Highbridge Parkrun,Scott Jenkins,M,GBR,23:32.0,?,
+25/12/2021,2021,3b 5km,Yes,Didcot Parkrun,Scott Jenkins,M,GBR,22:14.0,?,
+19/12/2021,2021,3b 10km,Yes,Aintree 10km,EJ Coldham,F,GBR,59:18.0,?,https://results.runthrough.co.uk/results.aspx?CId=16487&RId=4574&EId=2&dt=0&PageNo=4&adv=0
+19/12/2021,2021,3b 10km,Yes,Aintree 10km,JL Coldham,M,GBR,59:18.0,?,https://results.runthrough.co.uk/results.aspx?CId=16487&RId=4574&EId=2&dt=0&PageNo=4&adv=0
+19/12/2021,2021,3b Half Marathon,Yes,Aintree Half Marathon,Scott Jenkins,M,GBR,34:03.0,3,http://results.runthrough.co.uk/results.aspx?CId=16487&RId=4574&EId=5&dt=0&PageNo=1&adv=0
+18/12/2021,2021,3b 5km,Yes,"Dishley, Loughborough Parkrun",Scott Jenkins,M,GBR,29:54.0,?,
+04/12/2021,2021,3b 5km,Yes,Watermead Country Park Parkrun,Scott Jenkins,M,GBR,21:04.0,?,
+25/11/2021,2021,3b 5km,Yes,"Harrisburg Turkey Trot 5k, PA",Tim Ebersole,M,USA,21:02.0,?,https://falconracetiming.com/racetimes/SMT%20Turkey%20Trot%20AG%202021.htm
+20/11/2021,2021,3b 5km,Yes,"Dishley, Loughborough Parkrun",Scott Jenkins,M,GBR,21:23.0,?,
+07/11/2021,2021,3b Marathon,Yes,New York City Marathon,Jack Hirschowitz,M,USA,57:17.0,?,
+06/11/2021,2021,3b 5km,Yes,"Dishley, Loughborough Parkrun",Scott Jenkins,M,GBR,23:04.0,?,
+28/10/2021,2021,3b Marathon,Yes,"Time Trial, Yokohama",Koutaro Kawano,M,JPN,22:24.0,?,"https://www.strava.com/activities/6176836328 His first full marathon, a Japanese record"
+17/10/2021,2021,3b Marathon,Yes,Bedford Aerodrone Marathon,Tim Butler,M,GBR,15:15.0,?,https://www.joggling.co.uk/Marathon-List
+10/10/2021,2021,3b 10km,Yes,İstanbulu Koşuyorum Üsküdar Etabı 2021,Ferda Tekgül,M,TUR,52:54.0,?,https://event.spor.istanbul/eventresults.aspx
+10/10/2021,2021,3b Marathon,Yes,Chicago Marathon,Perry Romanowski,M,USA,49:05.0,?,https://chicago-history.r.mikatiming.com/2021/?pid=search
+10/10/2021,2021,3b Marathon,Yes,Manchester Marathon,Chris Edwin,M,GBR,50:15.0,15,
+03/10/2021,2021,3b Marathon,Yes,London Marathon,Ralph Kidner,M,GBR,51:33.0,?,https://www.runbritainrankings.com/results/results.aspx?meetingid=427704&event=Mar&venue=London&date=3-Oct-21
+02/10/2021,2021,3b 5km,Yes,"Dishley, Loughborough Parkrun",Scott Jenkins,M,GBR,22:15.0,?,
+26/09/2021,2021,3b Marathon,Yes,Berlin Marathon,Barak Hirschowitz,M,USA,25:18.0,0,https://www.bmw-berlin-marathon.com/en/impressions/statistics-and-history/results-archive/?
+26/09/2021,2021,3b Marathon,Yes,Berlin Marathon,Jack Hirschowitz,M,USA,59:49.0,0,https://www.bmw-berlin-marathon.com/en/impressions/statistics-and-history/results-archive/?
+25/09/2021,2021,3b 5km,Yes,"Dishley, Loughborough Parkrun",Scott Jenkins,M,GBR,22:32.0,?,
+19/09/2021,2021,3b Marathon,Yes,Rutland Water Marathon,Tim Butler,M,GBR,17:42.0,?,https://www.joggling.co.uk/Marathon-List
+19/09/2021,2021,3b Marathon,Yes,Ludwig Canal Time Trial,Peter Rupprecht,M,DEU,22:00.0,?,https://perujo.de/joggling-marathon-geschafft-in-5-stunden-und-22-minuten
+18/09/2021,2021,3b 5km,Yes,York Parkrun,Scott Jenkins,M,GBR,23:13.0,?,
+12/09/2021,2021,3b Half Marathon,Yes,"Auffahrtslauf St. Gallen Half Marathon, Switzerland",Daniel Raum,M,AUT,32:12.0,?,https://my.raceresult.com/163389/
+11/09/2021,2021,3b 5km,Yes,"Dishley, Loughborough Parkrun",Scott Jenkins,M,GBR,22:50.0,?,
+09/09/2021,2021,3b 10km,Yes,Time Trial,Gopi Devarajulu,M,IND,15:33.0,?,https://www.youtube.com/watch?v=1A8KjLwMQ3M
+05/09/2021,2021,3b 10km,Yes,İstanbul'u Koşuyorum Caddebostan Colour Run,Ferda Tekgül,M,TUR,55:22.0,?,https://event.spor.istanbul/eventresults.aspx
+04/09/2021,2021,3b 5km,Yes,"Dishley, Loughborough Parkrun",Scott Jenkins,M,GBR,22:16.0,?,
+28/08/2021,2021,3b 5km,Yes,Ashton Court Parkrun,Nati Tuppen,F,GBR,42:26.0,?,https://www.parkrun.org.uk/ashtoncourt/results/454/  https://www.parkrun.org.uk/ashtoncourt/news/2021/08/29/just-do-it-your-way-ashton-court-parkrun-454/
+21/08/2021,2021,3b 5km,Yes,Burnham and Highbridge Parkrun,Scott Jenkins,M,GBR,26:31.0,?,
+14/08/2021,2021,3b 5km,Yes,"Dishley, Loughborough Parkrun",Scott Jenkins,M,GBR,22:37.0,?,
+14/08/2021,2021,3b 5km,Yes,Eastville Parkrun,Nati Tuppen,F,GBR,35:30.0,?,https://www.parkrun.org.uk/eastville/news/2021/08/14/course-record-falls-and-joggling-comes-to-eastville-park/   https://www.parkrun.org.uk/eastville/results/121/
+14/08/2021,2021,3b Marathon,Yes,Horseshoe Challenge,Tim Butler,M,GBR,26:37.0,?,https://www.joggling.co.uk/Marathon-List
+21/07/2021,2021,3b Mile,Yes,"Harrisburg Mile Race, PA",Tim Ebersole,M,USA,05:47.0,?,https://falconracetiming.com/racetimes/Harrisburg%20Mile%20Overall%202021.htm
+10/07/2021,2021,3b Ultra (40m),No,Dukeries 40,Tim Butler,M,GBR,21:43.0,?,https://www.joggling.co.uk/Marathon-List
+19/06/2021,2021,3b Ultra (28m),No,The Halo Chesterfield,Tim Butler,M,GBR,50:08.0,?,https://www.joggling.co.uk/Marathon-List
+13/06/2021,2021,3b Half Marathon,Yes,"Dumb Dutchman Half Marathon, Reading, PA",Tim Ebersole,M,USA,36:35.0,?,https://www.pretzelcitysports.com/wp-content/uploads/2021/06/21-dd-half-results.pdf
+23/05/2021,2021,3b Marathon,Yes,Peterborough Marathon,Tim Butler,M,GBR,29:17.0,?,https://www.joggling.co.uk/Marathon-List
+08/05/2021,2021,3b Marathon,Yes,Colliery Canter,Tim Butler,M,GBR,10:02.0,?,https://www.joggling.co.uk/Marathon-List
+28/04/2021,2021,3b Mile,Yes,Time Trial,Koutaro Kawano,M,JPN,06:17.0,?,https://www.strava.com/activities/5204608300
+24/04/2021,2021,3b 5km,Yes,Time Trial,Toon Witters,M,BEL,22:19.0,15,https://www.strava.com/activities/5182010335
+04/04/2021,2021,3b 10km,Yes,N Kolay İstanbul Yarı Maratonu 2021,Ferda Tekgül,M,TUR,48:21.0,?,https://event.spor.istanbul/eventresults.aspx
+19/12/2020,2020,3b 5km,Yes,5km Joggling Challenge,EJ Coldham,F,GBR,30:20.0,?,https://www.strava.com/activities/4491314701/overview
+29/11/2020,2020,3b Marathon,Yes,Space Coast Marathon,Barak Hirschowitz,M,USA,46:03.0,?,https://marathonview.net/search?query=barak%20hirschowitz
+26/11/2020,2020,3b 10km,Yes,"Newport Turkey Trot 10k, PA",Tim Ebersole,M,USA,44:32.0,?,https://resultscui.active.com/events/2020NewportTurkeyTrot
+26/10/2020,2020,3b 10km,Yes,İstanbulu Koşuyorum Caddebostan Gazi Koşusu 2020,Ferda Tekgül,M,TUR,52:29.0,?,https://event.spor.istanbul/eventresults.aspx
+11/10/2020,2020,3b 10km,Yes,İstanbulu Koşuyorum Bakırköy Etabı 2020,Ferda Tekgül,M,TUR,50:55.0,?,https://event.spor.istanbul/eventresults.aspx
+12/09/2020,2020,3b Half Marathon,Yes,"Harrisburg Half Marathon, PA",Tim Ebersole,M,USA,29:56.0,0,https://falconracetiming.com/racetimes/Harrisburg%20Half%20Overall%202020.htm
+29/08/2020,2020,3b Marathon,Yes,Temple Newsam Marathon,Tim Butler,M,GBR,53:01.0,?,https://www.joggling.co.uk/Marathon-List
+22/08/2020,2020,3b Mile,Yes,Time Trial,Charlie Freeman,M,USA,05:06.0,1,https://www.tiktok.com/@cfreeman77/video/6863613020333985029
+14/07/2020,2020,3b Mile,Yes,Time Trial,Aaron Scott,M,USA,05:21.0,1,https://www.youtube.com/watch?v=OM97KJQIVAM
+25/04/2020,2020,3b 50km,Yes,Time Trial,John Riden,M,USA,49:11.0,?,https://www.strava.com/activities/3353955376
+16/04/2020,2020,5b Mile,Yes,Time Trial,Scott Jenkins,M,GBR,15:21.0,?,https://www.strava.com/activities/3307180189
+03/04/2020,2020,3b 5km,Yes,Time Trial,Aaron Scott,M,USA,17:47.0,1,https://www.youtube.com/watch?v=NYNBRc9AKHE
+08/03/2020,2020,3b Marathon,Yes,Los Angeles Marathon,Justin Delong,M,USA,03:25.0,?,https://www.instagram.com/p/B9n74FxlkSX/  http://results2.xacte.com/#/e/2353/searchable
+29/02/2020,2020,5b 5km,Yes,Cross Flats Parkrun,Dominic Lodge,M,GBR,50:00.0,?,"https://www.facebook.com/profile/100064422740314/search?q=juggle https://www.parkrun.org.uk/crossflatts/results/352/
 "
-25/02/2020,2020,3b Marathon,Yes,Salcey Forest Marathon,Tim Butler,M,GBR,04:56:07.00,?,https://www.joggling.co.uk/Marathon-List
-25/01/2020,2020,3b Ultra (30m),No,Waterways 30,Tim Butler,M,GBR,06:36:21.00,?,https://www.joggling.co.uk/Marathon-List
-18/01/2020,2020,3b Ultra (27m),No,Pierrepont 6 Hour,Tim Butler,M,GBR,04:27:53.00,?,https://www.joggling.co.uk/Marathon-List
-12/01/2020,2020,3b Marathon,Yes,Langsett Marathon,Tim Butler,M,GBR,05:29:33.00,?,https://www.joggling.co.uk/Marathon-List
-04/01/2020,2020,3b 5km,Yes,Gloucester City Parkrun,Jordan Evans,M,GBR,00:20:18.00,0,https://www.strava.com/activities/2980542307
-01/01/2020,2020,3b 5km,Yes,"Faelledparken Parkrun, Copenhagen",Malachy Kelly,M,IRL,00:25:57.00,?,https://www.parkrun.dk/faelledparken/results/429/    https://www.facebook.com/481403242254926/posts/pfbid02KABLv52gBKhJZQ76bSg44CHmNtbLAhoz1YM2cWETaQqrXSZNDPGs1dQz7ETtByRzl/?app=fbl
-01/01/2020,2020,3b 5km,Yes,"Amager Faelled Parkrun, Copenhagen",Malachy Kelly,M,IRL,00:27:18.00,?,https://www.parkrun.dk/amager/results/569/   https://www.facebook.com/481403242254926/posts/pfbid02KABLv52gBKhJZQ76bSg44CHmNtbLAhoz1YM2cWETaQqrXSZNDPGs1dQz7ETtByRzl/?app=fbl
-25/12/2019,2019,3b 5km,Yes,Sligo Parkrun,Malachy Kelly,M,IRL,00:23:36.00,?,https://www.parkrun.ie/sligo/results/254/
-21/12/2019,2019,3b 5km,Yes,Gloucester City Parkrun,Jordan Evans,M,GBR,00:22:03.00,2,https://www.strava.com/activities/2971205774
-21/12/2019,2019,3b 5km,Yes,Burnham and Highbridge Parkrun,Scott Jenkins,M,GBR,00:23:01.00,?,
-14/12/2019,2019,3b 5km,Yes,"Killarney House Parkrun, Ireland",Malachy Kelly,M,IRL,00:24:20.00,?,https://www.facebook.com/killarneyhouseparkrun/videos/473825933533323/?app=fbl     https://www.parkrun.ie/killarneyhouse/results/22/
-14/12/2019,2019,3b Marathon,Yes,Elsecar Marathon,Tim Butler,M,GBR,04:59:36.00,?,https://www.joggling.co.uk/Marathon-List
-08/12/2019,2019,3b 10km,Yes,Bebek Etabı İstanbulu Koşuyorum,Ferda Tekgül,M,TUR,00:49:51.00,?,https://event.spor.istanbul/eventresults.aspx
-08/12/2019,2019,3b 15km,No,"Bruggenloop, Rotterdam",Roy van Rijn,M,NLD,01:45:43.00,?,https://marathonphotos.live/Event/Sports%2FNFNL%2F2019%2FBruggenloop%20Rotterdam/9626#free   https://twitter.com/royvanrijn/status/1203735661641175040?t=gGl1n9Ktl6OiiY0rAWW56w&s=19
-01/12/2019,2019,3b 5km,Yes,"Middletown, New Jersey",Karly Swaim,F,USA,00:32:18.00,?,https://runsignup.com/Race/Results/38943/#resultSetId-182064;page:2;perpage:100
-28/11/2019,2019,3b 5km,Yes,"New Cumberland Turkey Trot 5k, PA",Tim Ebersole,M,USA,00:20:41.00,?,https://falconracetiming.com/racetimes/SMT%20Turkey%20Trot%20AG%202019.htm#%201%20M
-23/11/2019,2019,3b 5km,Yes,Mallow Castle Parkrun,Malachy Kelly,M,IRL,00:25:06.00,?,https://www.facebook.com/481403242254926/posts/880304059031507/?mibextid=rS40aB7S9Ucbxw6v
-16/11/2019,2019,3b Marathon,Yes,Rother Valley Park Marathon,Tim Butler,M,GBR,04:29:54.00,?,https://www.joggling.co.uk/Marathon-List
-11/11/2019,2019,3b 10km,Yes,Olsztyn Independence Run,Jarek Widomski,M,POL,00:48:22.00,?,
-03/11/2019,2019,3b 15km,No,Istanbul,Ferda Tekgül,M,TUR,01:29:50.00,?,https://event.spor.istanbul/eventresults.aspx
-03/11/2019,2019,3b Marathon,Yes,New York City Marathon,Barak Hirschowitz,M,USA,04:54:10.00,?,https://www.nyrr.org/tcsnycmarathon/getinspired/photos-and-stories/2020/jack-hirschowitz
-03/11/2019,2019,3b Marathon,Yes,New York City Marathon,Jack Hirschowitz,M,USA,04:56:52.00,?,https://results.nyrr.org/event/M2019/finishers#search=Hirschowitz&page=1
-28/10/2019,2019,3b Mile,Yes,Time Trial (GWR),David Rush,M,USA,00:07:54.00,?,Blindfolded! https://www.youtube.com/watch?v=TdYXwSeqxOk
-20/10/2019,2019,3b 10km,Yes,Sarasota 10km,Barak Hirschowitz,M,USA,00:56:18.00,?,
-20/10/2019,2019,3b Half Marathon,Yes,Amsterdam,Necmi Oztoprak,M,TUR,01:50:51.00,0,https://www.instagram.com/p/B32bLemgnSv/
-13/10/2019,2019,3b 10km,Yes,Munich,Necmi Oztoprak,M,TUR,00:46:14.00,0,https://www.instagram.com/p/B3mGtkLAt7M/  https://www.abavent.de/anmeldeservice/muenchenmarathon2019/ergebnisse?en#3_CF93CE
-13/10/2019,2019,3b Marathon,Yes,Chicago Marathon,Perry Romanowski,M,USA,03:43:46.00,?,https://chicago-history.r.mikatiming.com/2021/?pid=search
-06/10/2019,2019,3b 10km,Yes,İstanbulu Koşuyorum Bakırköy Etabı 2019,Ferda Tekgül,M,TUR,00:55:51.00,?,https://event.spor.istanbul/eventresults.aspx
-06/10/2019,2019,3b Half Marathon,Yes,Bridlington Half Marathon,Pete Barnard,M,GBR,02:11:16.00,2,https://www.sportstimingsolutions.co.uk/rcd_mobile.php?id=355&bib=114
-06/10/2019,2019,3b Marathon,Yes,"3-Länder-Marathon, Lindau, Germany",Daniel Raum,M,AUT,03:21:37.00,?,https://bregenz.r.mikatiming.de/2019/?pid=search
-05/10/2019,2019,4b 10km,Yes,"Runinaddu, Maldives ",Michal Kapral,M,CAN,00:55:48.00,?,https://runningmagazine.ca/the-scene/michal-kapral-sets-worlds-first-4-ball-joggling-10k-record-in-paradise/
-28/09/2019,2019,3b 5km,Yes,Mill Race 5km,John Riden,M,USA,00:29:16.00,4,https://www.strava.com/activities/2746941936
-22/09/2019,2019,3b Marathon,Yes,Rutland Water Marathon,Tim Butler,M,GBR,04:49:25.00,?,https://www.joggling.co.uk/Marathon-List
-15/09/2019,2019,3b 10km,Yes,Tübingen Heritage Run,Peter Rottenbach,M,DEU,00:58:45.00,?,https://my.raceresult.com/119388/#0_E863AF 
-14/09/2019,2019,3b 10km,Yes,VI Run Grand Prix Warsaw,Jarek Widomski,M,POL,00:45:15.00,2,
-08/09/2019,2019,3b Half Marathon,Yes,Harrisburg Half Marathon,Tim Ebersole,M,USA,01:32:59.00,2,https://falconracetiming.com/racetimes/Harrisburg%20Half%20Marathon%20Overall%202019.htm
-08/09/2019,2019,3b Half Marathon,Yes,Maybank Bali Marathon,Levent Denizci,M,TUR,02:14:32.00,3,https://www.instagram.com/p/B2qhaW0g48r/  https://www.instagram.com/p/B2Llfk0AXco/
-01/09/2019,2019,3b Marathon,Yes,York Turbin Challenge,Tim Butler,M,GBR,04:55:00.00,?,https://www.joggling.co.uk/Marathon-List
-25/08/2019,2019,3b Marathon,Yes,Santa Rosa Marathon,Barak Hirschowitz,M,USA,04:31:11.00,?,https://marathonview.net/search?query=barak%20hirschowitz
-15/08/2019,2019,3b Half Marathon,Yes,Aleksandrow Zodzki Half Marathon,Jarek Widomski,M,POL,01:44:35.00,0,
-27/07/2019,2019,3b Ultra (44.9m),No,Dusk Till Dawn,Tim Butler,M,GBR,12:00:00.00,?,https://www.joggling.co.uk/Marathon-List
-17/07/2019,2019,3b 10km,Yes,Bungay 10km,John Jervis,M,GBR,00:47:42.00,7,https://www.runbritainrankings.com/results/results.aspx?meetingid=297940&event=10KMT&venue=Bungay&date=17-Jul-19
-06/07/2019,2019,3b Marathon,Yes,York Interstellar Marathon,Tim Butler,M,GBR,04:20:58.00,?,https://www.joggling.co.uk/Marathon-List
-27/06/2019,2019,3b 5km,Yes,"St. Peter's Fiesta 5km, Gloucester, MA",Richard Ross,M,USA,00:19:59.00,?,https://www.instagram.com/p/BzQTDEWhe-X/  https://newenglandruns.com/race-results/st-peters-fiesta-5k/?date=2019-06-27&result=43122&bib=ross&gender=&division=&order_by=finish_time&order=ASC
-16/06/2019,2019,3b 5km,Yes,"Evanston Race Against Hate, IL",Dean Radcliffe,M,USA,00:25:10.00,?,https://results.raceroster.com/v2/en-US/results/urrk4wsy39e9crfs/results?subEvent=25982&page=1&search=Dean+radcliffe
-16/06/2019,2019,3b Marathon,Yes,Bahtat Marathon,Tim Butler,M,GBR,05:33:23.00,?,https://www.joggling.co.uk/Marathon-List
-15/06/2019,2019,3b 13km,No,Sapanca ultra 13K,Ferda Tekgül,M,TUR,01:28:27.00,?,https://onedrive.live.com/?authkey=%21ADr22XJVkZDvUAU&cid=D218D0DBBD3CA6B9&id=D218D0DBBD3CA6B9%21143009&parId=D218D0DBBD3CA6B9%21188717&o=OneUp
-09/06/2019,2019,3b Half Marathon,Yes,"Dumb Dutchman Half Marathon, Reading, PA",Tim Ebersole,M,USA,01:38:42.00,17,https://www.pretzelcitysports.com/wp-content/uploads/2019/06/19-reading-dumb-half-res.pdf
-08/06/2019,2019,3b 5km,Yes,"Blue Nose 5k, Halifax, Nova Scotia",Michael-Lucien Bergeron,M,CAN,00:17:16.00,?,https://www.sportstats.ca/display-results.xhtml?raceid=100727&status=results&lastname=Bergeron    https://www.facebook.com/664250217053533/posts/pfbid02AgUtA5gMLKM8xnTKednYBmKC4xshKLLrVbZs8PcD2xoLobwPAifzwaotF4kj43N2l/?app=fbl
-02/06/2019,2019,3b Marathon,Yes,Huddersfield Marathon,Tim Butler,M,GBR,05:06:13.00,?,https://www.joggling.co.uk/Marathon-List  https://www.doncasterathleticclub.com/results-update-3-june-2019-huddersfield-humber-bridge-half-escape-from-gb-calderdale-way-ultra-and-parkruns/?fbclid=IwAR3YhCfSbUN5tPfdy8Hm7N_xGcg4rVoxfEO6oARGG_bbrtOh0nlvXz_T0oM
-26/05/2019,2019,3b Marathon,Yes,Winterthur Marathon,Daniel Raum,M,AUT,03:22:58.00,?,https://services.datasport.com/2019/lauf/winterthur/rang010.htm
-18/05/2019,2019,3b 10km,Yes,Bozcaada,Necmi Oztoprak,M,TUR,00:53:31.00,3,https://www.instagram.com/p/Bxmx3Zdh2P5/
-18/05/2019,2019,3b 10km,Yes,Bozcaada,Levent Denizci,M,TUR,01:02:16.00,2,https://www.instagram.com/p/BxmoEpphnga/
-18/05/2019,2019,3b Marathon,Yes,Fargo Marathon,Ivan Schleppenbach,M,USA,03:44:42.00,?,https://www.mtecresults.com/runner/show?race=8184&rid=1211
-11/05/2019,2019,3b Ultra (33m),No,Chesterfield Spire Ultra,Tim Butler,M,GBR,07:06:13.00,?,https://www.joggling.co.uk/Marathon-List
-05/05/2019,2019,3b Marathon,Yes,Vancouver Marathon,Nigel Wakita,M,CAN,04:01:12.00,6,https://www.instagram.com/p/BxGYO6IgjoJ/?hl=en
-27/04/2019,2019,3b 5km,Yes,Cardiff Parkrun,Pete Barnard,M,GBR,00:29:53.00,?,https://www.parkrun.org.uk/cardiff/results/594/     https://twitter.com/speirce/status/1122092919303868416
-21/04/2019,2019,3b Marathon,Yes,Northampton Chocathon,Tim Butler,M,GBR,04:47:09.00,?,https://www.joggling.co.uk/Marathon-List
-14/04/2019,2019,3b Marathon,Yes,Peterborough Marathon,Tim Butler,M,GBR,04:24:54.00,?,https://www.joggling.co.uk/Marathon-List
-13/04/2019,2019,3b Marathon,Yes,"Linz Marathon, Austria",Daniel Raum,M,AUT,03:14:19.00,?,https://linzmarathon.r.mikatiming.de/2019/?pid=search
-07/04/2019,2019,3b 10km,Yes,Vodafone İstanbul Yarı Maratonu 2019,Ferda Tekgül,M,TUR,01:06:54.00,?,https://event.spor.istanbul/eventresults.aspx
-07/04/2019,2019,3b Half Marathon,Yes,Bonn Half Marathon,Peter Meyer,M,DEU,02:14:57.00,4,50% 4 balls
-30/03/2019,2019,3b 5km,Yes,Leicester Victoria Parkrun,Scott Jenkins,M,GBR,00:25:39.00,?,
-23/03/2019,2019,3b Marathon,Yes,Yorkshire Cakeathon,Tim Butler,M,GBR,04:58:51.00,?,https://www.joggling.co.uk/Marathon-List
-16/03/2019,2019,3b 5km,Yes,Gloucester City Parkrun,Jordan Evans,M,GBR,00:20:48.00,2,https://www.strava.com/activities/2222976844
-10/03/2019,2019,3b Marathon,Yes,Cambridge Boundary Run,Tim Butler,M,GBR,04:53:28.00,?,https://www.joggling.co.uk/Marathon-List
-09/02/2019,2019,3b 12km,No,Manavgat ultra  12k,Ferda Tekgül,M,TUR,01:51:39.00,?,https://limitsensin.org/live/results/manavgatultra2019/12K
-27/01/2019,2019,3b Marathon,Yes,Celebration Orlando Marathon,Barak Hirschowitz,M,USA,05:08:29.00,?,https://marathonview.net/search?query=barak%20hirschowitz
-19/01/2019,2019,3b Ultra (30m),No,Pierrepont 6 Hour,Tim Butler,M,GBR,05:39:44.00,?,https://www.joggling.co.uk/Marathon-List
-01/01/2019,2019,3b 5km,Yes,Armley Parkrun,Ralph Kidner,M,GBR,00:31:01.00,?,https://www.parkrun.org.uk/armley/results/29/ https://m.facebook.com/story.php?story_fbid=pfbid0S5Y7CWHugGrM2R3UnDsNUshTjfSs29GTfhidBuUhGMNM1h6ufibYEvqhRzzmm3XFl&id=587811608285641
-28/12/2018,2018,3b Marathon,Yes,Barrow Xmas Tipple,Tim Butler,M,GBR,04:56:44.00,?,https://www.joggling.co.uk/Marathon-List
-17/11/2018,2018,3b Marathon,Yes,Kirkstall Abbey Marathon,Tim Butler,M,GBR,04:37:54.00,?,https://www.joggling.co.uk/Marathon-List
-10/11/2018,2018,3b 5km,Yes,Dinton Pastures Parkrun,Stuart Humphries,M,GBR,00:24:20.00,?,https://www.parkrun.org.uk/dintonpastures/results/18/   https://www.parkrun.org.uk/dintonpastures/news/2018/11/12/dinton-pastures-parkrun-18/
-04/11/2018,2018,3b 5km,Yes,Time Trial,Sterling Franklin,M,USA,00:19:32.00,0,https://www.youtube.com/watch?v=4pMKerapCpk
-04/11/2018,2018,3b 10km,Yes,Leeds Abbey Dash,Pete Barnard,M,GBR,00:59:29.00,0,https://results.sporthive.com/events/6460069711597044224/races/446670
-04/11/2018,2018,3b 10km,Yes,Leeds Abbey Dash,Ralph Kidner,M,GBR,01:00:29.00,4,https://results.sporthive.com/events/6460069711597044224/races/446670
-04/11/2018,2018,3b Marathon,Yes,New York City Marathon,Jack Hirschowitz,M,USA,04:51:10.00,?,https://results.nyrr.org/event/M2018/finishers#search=Jack%2520Hirschowitz
-21/10/2018,2018,3b Half Marathon,Yes,Toronto Waterfront Half Marathon,Michael-Lucien Bergeron,M,CAN,01:17:09.00,?,https://runningmagazine.ca/sections/runs-races/bergeron-breaks-half-marathon-joggling-record/
-21/10/2018,2018,3b Half Marathon,Yes,Toronto Waterfront Half Marathon,Graydon Snider,M,CAN,01:17:11.00,?,https://runningmagazine.ca/sections/runs-races/bergeron-breaks-half-marathon-joggling-record/
-21/10/2018,2018,3b Marathon,Yes,"Yonkers Marathon, New York",Chris Pert,M,USA,04:30:30.00,?,https://marathonview.net/search?query=christopher%20pert
-20/10/2018,2018,3b 5km,Yes,Trick or Trot 5km,Tyler Wishau,M,USA,00:21:04.00,0,https://www.facebook.com/profile/100064067107732/search/?q=joggling
-14/10/2018,2018,3b Marathon,Yes,Spires and Steeples,Tim Butler,M,GBR,05:33:00.00,?,https://www.joggling.co.uk/Marathon-List
-07/10/2018,2018,3b 10km,Yes,Southend 10km,Jordan Evans,M,GBR,00:41:20.00,?,https://www.strava.com/activities/1889442921
-07/10/2018,2018,3b Marathon,Yes,Chicago Marathon,Perry Romanowski,M,USA,03:45:13.00,?,https://chicago-history.r.mikatiming.com/2021/?pid=search
-07/10/2018,2018,3b Marathon,Yes,Chicago Marathon,Sarah Szefi,F,USA,04:02:30.00,?,https://chicago-history.r.mikatiming.com/2021/?pid=search
-30/09/2018,2018,3b Half Marathon,Yes,Cheltenham Half Marathon,Jordan Evans,M,GBR,01:26:55.00,?,
-29/09/2018,2018,3b Marathon,Yes,Warsaw Marathon,Jarek Widomski,M,POL,03:39:54.00,7,
-15/09/2018,2018,3b 5km,Yes,Dalby Forest Parkrun,Pete Barnard,M,GBR,00:26:24.00,?,https://www.parkrun.org.uk/dalbyforest/results/127/  https://www.parkrun.org.uk/dalbyforest/news/2018/09/23/event-127-return-of-the-joggler/
-09/09/2018,2018,3b 10km,Yes,Pied Piper 10km,Jordan Evans,M,GBR,00:41:53.00,?,https://www.strava.com/activities/1829732164
-02/09/2018,2018,3b Marathon,Yes,Hornsea Marathon,Tim Butler,M,GBR,04:22:23.00,?,https://www.joggling.co.uk/Marathon-List
-30/08/2018,2018,3b Mile,Yes,Time Trial,Scott Jenkins,M,GBR,00:06:58.00,0,
-19/08/2018,2018,3b 10km,Yes,"Navy 10k Race, Halifax, Nova Scotia",Michael-Lucien Bergeron,M,CAN,00:35:36.00,?,https://athleticsillustrated.com/michael-lucien-bergerons-ballsy-joggling-nets-him-a-world-10k-record/    https://runningmagazine.ca/the-scene/canadian-runs-5000m-joggling-world-record-of-1650/
-18/08/2018,2018,3b 5km,Yes,Frédéric Back parkrun,Graydon Snider,M,CAN,00:16:57.00,0,https://www.parkrun.ca/fredericback/news/2018/09/15/highlights-from-the-last-few-weeks/  https://www.parkrun.ca/fredericback/results/58/
-12/08/2018,2018,3b Marathon,Yes,Rocky Horror Tribute Marathon,Tim Butler,M,GBR,04:52:41.00,?,https://www.joggling.co.uk/Marathon-List
-28/07/2018,2018,3b 5km,Yes,Gloucester North Parkrun,Jordan Evans,M,GBR,00:21:26.00,?,https://www.strava.com/activities/1732580500
-28/07/2018,2018,3b Marathon,Yes,Dusk Till Dawn,Tim Butler,M,GBR,04:56:48.00,?,https://www.joggling.co.uk/Marathon-List
-04/07/2018,2018,3b 4 Mile,No,Firecracker 4,Tony Malikowski,M,USA,00:35:35.00,?,https://runsignup.com/Race/Results/27413#resultSetId-123798;perpage:100
-01/07/2018,2018,3b Marathon,Yes,Halifax Marathon,Tim Butler,M,GBR,04:48:57.00,?,https://www.joggling.co.uk/Marathon-List
-02/06/2018,2018,3b Half Marathon,Yes,Grand Teton Half Marathon,Scott Gorman,M,USA,02:06:35.00,?,https://www.facebook.com/photo/?fbid=10102571142247321&set=a.682390132741  https://runsignup.com/Race/Results/36796#resultSetId-118559;perpage:100
-27/05/2018,2018,3b Marathon,Yes,"Winterthur Marathon, Switzerland",Daniel Raum,M,AUT,04:14:19.00,?,https://services.datasport.com/2018/lauf/winterthur/alfar.htm
-20/05/2018,2018,3b Ultra (35m),No,Shires and Spires Ultra,Tim Butler,M,GBR,06:50:43.00,?,https://www.joggling.co.uk/Marathon-List
-19/05/2018,2018,3b 5km,Yes,"Blue Nose 5k, Halifax, Nova Scotia",Michael-Lucien Bergeron,M,CAN,00:17:01.00,?,https://www.sportstats.ca/display-results.xhtml?raceid=93319     https://www.facebook.com/664250217053533/posts/pfbid0219Yu1yTQzrGpqUzeYuti47oUfMr1RHohS3bhUrdxFH89RQh6iLr4qMkCR7Wacb9Rl/?app=fbl
-19/05/2018,2018,3b 5km,Yes,"Blue Nose 5k, Halifax, Nova Scotia",Bradley Fiander,M,CAN,00:19:44.00,?,https://www.sportstats.ca/display-results.xhtml?raceid=93319&status=results&bib=9207     https://www.facebook.com/664250217053533/posts/pfbid026Q8wfDQrDtNwPhxy9kixvJSxzPoa62mcs3kfx9te2VsD5PViKr5DnzvxC4JRf17Xl/?app=fbl
-19/05/2018,2018,3b Marathon,Yes,Fargo Marathon,Ivan Schleppenbach,M,USA,03:28:29.00,?,https://www.mtecresults.com/runner/show?race=6660&rid=463
-11/05/2018,2018,3b Half Marathon,Yes,Fredericton Half Marathon,Michael-Lucien Bergeron,M,CAN,01:20:50.00,?,https://www.saltwire.com/nova-scotia/sports/video-bergeron-combines-running-and-juggling-243982/   https://results.raceroster.com/en-CA/results/detail/chxvfrgp4wa9fz63
-10/05/2018,2018,3b Half Marathon,Yes,"Auffahrtslauf St. Gallen Half Marathon, Switzerland",Daniel Raum,M,AUT,01:40:20.00,?,https://my.raceresult.com/85080/#1_C8F593
-08/05/2018,2018,3b Mile,Yes,Time Trial,Zach Prescott,M,USA,00:04:43.00,?,https://www.runnersworld.com/runners-stories/a20732918/joggler-sets-a-world-record-in-the-mile/
-06/05/2018,2018,3b Marathon,Yes,Roche Abbey Marathon,Tim Butler,M,GBR,05:38:04.00,?,https://www.joggling.co.uk/Marathon-List
-05/05/2018,2018,3b 5km,Yes,Sewerby Parkrun,Pete Barnard,M,GBR,00:31:12.00,0,https://www.parkrun.org.uk/sewerby/results/335/ https://m.facebook.com/story.php?story_fbid=pfbid032JYDayTNJ4AKADEDA61CW5ZCboGmHMtsAA5L3YMzv1LmUPhBbvnWWBhpfbZ5REASl&id=765064822
-22/04/2018,2018,3b Marathon,Yes,"Zurich Marathon, Switzerland",Daniel Raum,M,AUT,03:59:46.00,?,https://services.datasport.com/2018/lauf/zuerich/alfar.htm
-22/04/2018,2018,3b Marathon,Yes,London Marathon,Tim Butler,M,GBR,05:13:39.00,?,https://www.joggling.co.uk/Marathon-List
-15/04/2018,2018,3b Marathon,Yes,Brighton Marathon,Jordan Evans,M,GBR,03:34:38.00,?,
-14/04/2018,2018,3b 5km,Yes,Kingsway Parkrun,Jordan Evans,M,GBR,00:19:44.00,?,https://www.strava.com/activities/1507147677
-08/04/2018,2018,3b Marathon,Yes,Bungay Marathon,Tim Butler,M,GBR,04:27:09.00,?,https://www.joggling.co.uk/Marathon-List
-08/04/2018,2018,3b Marathon,Yes,Rome Marathon,Jack Hirschowitz,M,USA,05:06:04.00,?,https://www.facebook.com/photo/?fbid=2026070107465749&set=gm.882770911894760  https://marathonview.net/search?query=jack%20hirschowitz
-02/04/2018,2018,3b Marathon,Yes,GBC Barrow Day 4,Tim Butler,M,GBR,04:56:48.00,?,https://www.joggling.co.uk/Marathon-List
-25/03/2018,2018,3b 50 Mile,Yes,"Charlottesville, Virginia",Rick Kwiatkowski,M,USA,07:53:55.00,?,https://www.guinnessworldrecords.com/world-records/fastest-50-miles-joggling
-17/03/2018,2018,3b 5km,Yes,Kilkenny Parkrun,Malachy Kelly,M,IRL,00:26:32.00,?,https://www.parkrun.ie/kilkenny/results/175/  https://fb.watch/lONEFREqLf/
-17/03/2018,2018,3b Half Marathon,Yes,"Wrightsville Beach Half Marathon, North Carolina",Terry Odom,M,USA,02:16:56.00,16,clubs http://roguerunners.org/WBhalfmarathon18.htm    https://www.wect.com/story/37755742/nc-man-completes-wrightsville-beach-half-marathon-while-juggling/
-10/03/2018,2018,3b 5km,Yes,Gloucester City Parkrun,Jordan Evans,M,GBR,00:18:51.00,?,https://www.strava.com/activities/1445037548  https://www.parkrun.org.uk/gloucestercity/results/2/
-04/03/2018,2018,3b Half Marathon,Yes,Paris Half Marathon,Levent Denizci,M,TUR,02:01:09.00,5,https://www.instagram.com/p/Bf5tx4UjS9B/
-17/12/2017,2017,3b Marathon,Yes,Newark Showground Day 2,Tim Butler,M,GBR,05:09:19.00,?,https://www.joggling.co.uk/Marathon-List
-16/12/2017,2017,3b Marathon,Yes,Newark Showground Day 1,Tim Butler,M,GBR,05:34:00.00,?,https://www.joggling.co.uk/Marathon-List
-03/12/2017,2017,3b Marathon,Yes,Christmas Marathon,Tim Butler,M,GBR,04:34:42.00,?,https://www.joggling.co.uk/Marathon-List
-26/11/2017,2017,3b 10km,Yes,Gloucester 10km,Jordan Evans,M,GBR,00:39:32.00,?,https://www.strava.com/activities/1291259819 https://www.thepowerof10.info/resultsfiles/2017/222094_7901_05122017010351_GLOS.pdf
-26/11/2017,2017,3b 10km,Yes,Doncaster 10k,Pete Barnard,M,GBR,01:05:33.00,0,https://racetimingsolutions.racetecresults.com/Search.aspx?CId=16269&RId=808&S=Barnard     https://www.facebook.com/765064822/posts/pfbid0omvHhgfAT2zPhZ9nX4PYSe1Sp2qJLBtZzjTyiKnuPzjy4Li2Dg3VHdMgTxGW6f4Bl/?app=fbl
-25/11/2017,2017,3b 10km,Yes,Bodrun Ultra 2017,Ferda Tekgül,M,TUR,01:05:58.00,?,https://onedrive.live.com/?authkey=%21AESvHE3mopXxiiM&cid=D218D0DBBD3CA6B9&id=D218D0DBBD3CA6B9%21142974&parId=D218D0DBBD3CA6B9%21170908&o=OneUp
-17/11/2017,2017,3b Marathon,Yes,Kirkstall Abbey Marathon,Tim Butler,M,GBR,04:55:00.00,?,https://www.joggling.co.uk/Marathon-List
-11/11/2017,2017,3b 5km,Yes,Hull Parkrun,Pete Barnard,M,GBR,00:30:59.00,?,https://www.parkrun.org.uk/hull/news/2017/11/13/event-404-11th-november-2017-by-claire-hughes/
-05/11/2017,2017,3b Marathon,Yes,New York City Marathon,Jack Hirschowitz,M,USA,04:57:36.00,?,https://results.nyrr.org/event/M2017/finishers#search=Jack%2520Hirschowitz
-22/10/2017,2017,3b Half Marathon,Yes,Stroud Half Marathon,Jordan Evans,M,GBR,01:30:01.00,?,https://www.strava.com/activities/1241841107
-22/10/2017,2017,3b Marathon,Yes,Ventura Marathon,Perry Romanowski,M,USA,03:56:34.00,?,https://marathonview.net/result/51051873
-21/10/2017,2017,3b 5km,Yes,Gloucester North Parkrun,Jordan Evans,M,GBR,00:21:24.00,?,https://www.strava.com/activities/1239818353
-15/10/2017,2017,3b Half Marathon,Yes,Prince Edward Island Half Marathon,Michael-Lucien Bergeron,M,CAN,01:21:34.00,6,https://runningmagazine.ca/sections/runs-races/michael-bergeron-2017-pei-half-marathon/     https://peiroadrunners.ca/results/2017/pei-marathon/13.1mi/
-01/10/2017,2017,3b Half Marathon,Yes,Cheltenham Half Marathon,Jordan Evans,M,GBR,01:32:17.00,?,https://www.strava.com/activities/1209848764
-30/09/2017,2017,3b 5km,Yes,Gloucester North Parkrun,Jordan Evans,M,GBR,00:19:57.00,?,https://www.strava.com/activities/1208265120
-24/09/2017,2017,3b Marathon,Yes,Nottingham Marathon,Tim Butler,M,GBR,04:43:42.00,?,https://www.joggling.co.uk/Marathon-List
-23/09/2017,2017,3b 5km,Yes,Kingsway Parkrun,Jordan Evans,M,GBR,00:18:54.00,0,https://www.strava.com/activities/1197014312
-17/09/2017,2017,3b Marathon,Yes,"Seenlandmarathon, Pleinfeld, Germany",Daniel Raum,M,AUT,03:37:00.00,?,https://www.nordbayern.de/region/wei%C3%9Fenburg/den-kompletten-marathon-jongliert-1.6643622?isAmp=true
-10/09/2017,2017,3b Marathon,Yes,Iceni Marathon (Thetford),Tim Butler,M,GBR,05:06:54.00,?,https://www.joggling.co.uk/Marathon-List
-09/09/2017,2017,3b 5km,Yes,Hadleigh Parkrun,Jordan Evans,M,GBR,00:21:07.00,?,https://www.parkrun.org.uk/hadleigh/news/2017/09/13/hadleigh-parkrun-45-the-parkrun-juggler-or-should-we-call-him-the-parkrun-joggler/
-02/09/2017,2017,3b 5km,Yes,Worcester Pitchcroft Parkrun,Jordan Evans,M,GBR,00:19:00.00,?,https://www.strava.com/activities/1163922574  https://www.parkrun.org.uk/worcesterpitchcroft/results/12/
-19/08/2017,2017,3b 5km,Yes,Cheltenham Parkrun,Jordan Evans,M,GBR,00:20:18.00,?,https://www.strava.com/activities/1140724011
-12/08/2017,2017,3b 5km,Yes,Sewerby Parkrun,Pete Barnard,M,GBR,00:35:06.00,?,https://www.parkrun.org.uk/sewerby/results/298/  https://fb.watch/lONDsC92AI/
-05/08/2017,2017,3b 5km,Yes,Tewkesbury Parkrun,Jordan Evans,M,GBR,00:19:43.00,?,https://www.strava.com/activities/1117927066
-30/07/2017,2017,3b 10km,Yes,Gloucester Race 4 Men,Jordan Evans,M,GBR,00:44:15.00,?,https://www.strava.com/activities/1108372759
-29/07/2017,2017,3b 5km,Yes,"Windsor 5k Fun Run, Nova Scotia",Bradley Fiander,M,CAN,00:20:45.00,?,https://results.raceroster.com/v2/en-CA/results/rvd77z5qbtrc4q3c/results?subEvent=&search=Fiander&page=1    https://www.facebook.com/513379212/posts/10155174605369213/?substory_index=652552003056853&app=fbl
-29/07/2017,2017,3b 5km,Yes,Cheltenham Parkrun,Jordan Evans,M,GBR,00:20:50.00,?,https://www.strava.com/activities/1106537994
-29/07/2017,2017,3b Ulta (41.7m),No,Dusk Till Dawn,Tim Butler,M,GBR,12:00:00.00,?,https://www.joggling.co.uk/Marathon-List
-08/07/2017,2017,3b 5km,Yes,Forest of Dean Parkrun,Jordan Evans,M,GBR,00:21:14.00,?,https://www.strava.com/activities/1073066127
-01/07/2017,2017,3b 5km,Yes,Hockley Woods Parkrun,Jordan Evans,M,GBR,00:20:54.00,?,https://www.parkrun.org.uk/hockleywoods/results/123/  https://www.strava.com/activities/1061860974
-24/06/2017,2017,3b 5km,Yes,Gloucester North Parkrun,Jordan Evans,M,GBR,00:21:17.00,?,https://www.strava.com/activities/1051235595
-18/06/2017,2017,3b 10km,Yes,"Running of the Balls 10k, New York",Richard Ross,M,USA,00:46:29.00,?,https://nycruns.com/race-results?race=the-running-of-the-balls-5k-10k-2&result=241746
-18/06/2017,2017,3b 10km,Yes,"Running of the Balls 10k, New York",Jack Hirschowitz,M,USA,01:00:01.00,?,https://nycruns.com/race-results?race=the-running-of-the-balls-5k-10k-2&result=241892
-17/06/2017,2017,3b 5km,Yes,Gloucester North Parkrun,Jordan Evans,M,GBR,00:20:39.00,?,https://www.strava.com/activities/1040339086
-10/06/2017,2017,3b 5km,Yes,Kingsway Parkrun,Jordan Evans,M,GBR,00:20:14.00,?,https://www.strava.com/activities/1029177556
-04/06/2017,2017,3b Ulta (35m),No,Shires and Spires Ultra,Tim Butler,M,GBR,06:52:16.00,?,https://www.joggling.co.uk/Marathon-List
-03/06/2017,2017,3b 5km,Yes,Kingsway Parkrun,Jordan Evans,M,GBR,00:21:17.00,?,https://www.strava.com/activities/1018599588
-28/05/2017,2017,3b Marathon,Yes,Edinburgh Marathon,Tim Butler,M,GBR,04:35:41.00,?,https://www.joggling.co.uk/Marathon-List
-27/05/2017,2017,3b 5km,Yes,Gloucester North Parkrun,Jordan Evans,M,GBR,00:21:41.00,?,https://www.strava.com/activities/1011523706
-20/05/2017,2017,3b 5km,Yes,"Blue Nose 5k, Halifax, Nova Scotia",Michael-Lucien Bergeron,M,CAN,00:17:47.00,?,https://www.sportstats.ca/display-results.xhtml?raceid=42181&status=results&lastname=Bergeron     https://www.facebook.com/664250217053533/posts/pfbid02AgUtA5gMLKM8xnTKednYBmKC4xshKLLrVbZs8PcD2xoLobwPAifzwaotF4kj43N2l/?app=fbl
-20/05/2017,2017,3b Half Marathon,Yes,Fargo Half Marathon,Ivan Schleppenbach,M,USA,01:39:26.00,?,https://www.mtecresults.com/runner/show?race=5201&rid=3583  https://www.inforum.com/sports/fargo-marathon-juggler-returns-to-the-half-marathon
-17/04/2017,2017,3b Marathon,Yes,Boston Marathon,Michael-Lucien Bergeron,M,CAN,03:13:12.00,4,
-17/04/2017,2017,3b Marathon,Yes,"Boston Marathon, Lincolnshire",Tim Butler,M,GBR,04:07:30.00,?,https://www.joggling.co.uk/Marathon-List
-09/04/2017,2017,3b Marathon,Yes,"Zurich Marathon, Switzerland",Daniel Raum,M,AUT,03:19:36.00,?,https://services.datasport.com/2017/lauf/zuerich/alfar.htm
-02/04/2017,2017,3b Half Marathon,Yes,Berlin Half Marathon,Levent Denizci,M,TUR,02:01:12.00,3,https://www.generali-berliner-halbmarathon.de/en/your-race/results-archive/  https://www.instagram.com/p/Bxyq8-FgTc5/
-13/03/2017,2017,3b 10km,Yes,SEDENA 10km,Jorge Vilchis,M,MEX,00:55:53.00,1,https://www.instagram.com/reel/BRlnTukgLnd/
-11/03/2017,2017,3b Marathon,Yes,Leeds Canel Canter,Tim Butler,M,GBR,04:52:38.00,?,https://www.joggling.co.uk/Marathon-List
-20/11/2016,2016,3b Marathon,Yes,Brooklyn Marathon,Chris Pert,M,USA,04:16:20.00,0,https://marathonview.net/search?query=christopher%20pert
-19/11/2016,2016,3b Marathon,Yes,Maravan 1,Tim Butler,M,GBR,05:14:35.00,?,https://www.joggling.co.uk/Marathon-List
-06/11/2016,2016,3b Marathon,Yes,New York City Marathon,Jack Hirschowitz,M,USA,04:53:00.00,?,https://results.nyrr.org/event/M2016/finishers#search=Jack%2520Hirschowitz
-30/10/2016,2016,3b Half Marathon,Yes,River Thames Half Marathon,Kevin Williams,M,GBR,02:00:12.00,7,https://www.jogglathon.co.uk/   https://www.sportsystems.co.uk/ss/results/athlete/?entId=WILLI-DHEIM-KEVNN
-23/10/2016,2016,3b 10 Mile,No,Great South Run,Kevin Williams,M,GBR,01:27:03.00,3,https://www.jogglathon.co.uk/  https://www.greatrun.org/results/584/8507/
-23/10/2016,2016,3b Marathon,Yes,Leicester Marathon,Tim Butler,M,GBR,04:27:51.00,?,https://www.joggling.co.uk/Marathon-List
-16/10/2016,2016,3b Half Marathon,Yes,Great Birmingham Run,Kevin Williams,M,GBR,01:58:13.00,2,https://www.jogglathon.co.uk/   https://www.greatrun.org/results/585/18760/
-12/10/2016,2016,3b 10km,Yes,Milan 10km (Dee Jay 10),Levent Denizci,M,TUR,00:50:38.00,0,https://www.instagram.com/p/BgVHirAgPhN/  https://www.instagram.com/p/BLc4Hh3jnwm/
-09/10/2016,2016,3b Half Marathon,Yes,Royal Parks Foundation Half Marathon,Kevin Williams,M,GBR,02:02:09.00,5,https://www.jogglathon.co.uk/     https://chiptiming.co.uk/events/royal-parks-foundation-half-marathon-2016/4943/
-09/10/2016,2016,3b Marathon,Yes,Chicago Marathon,Michal Kapral,M,CAN,02:55:25.00,0,https://chicago-history.r.mikatiming.com/2021/?pid=search
-09/10/2016,2016,3b Marathon,Yes,Chicago Marathon,Perry Romanowski,M,USA,03:49:14.00,?,https://chicago-history.r.mikatiming.com/2021/?pid=search
-02/10/2016,2016,3b Half Marathon,Yes,Tonbridge Half Marathon,Kevin Williams,M,GBR,02:10:00.00,2,https://www.jogglathon.co.uk/
-02/10/2016,2016,3b Marathon,Yes,Mablethorpe Marathon,Tim Butler,M,GBR,04:45:18.00,?,https://www.joggling.co.uk/Marathon-List
-18/09/2016,2016,3b Marathon,Yes,"Seenlandmarathon, Pleinfeld, Germany",Daniel Raum,M,AUT,03:55:31.00,?,https://seenlandmarathon2016.racepedia.de/ergebnisse/1136
-05/08/2016,2016,3b Half Marathon,Yes,Runtalya,Levent Denizci,M,TUR,02:12:10.00,4,https://www.instagram.com/p/BItmGofD3se/
-30/07/2016,2016,3b Mile,Yes,"IJA, El Paso, Texas",Gabrielle Foran,F,CAN,00:05:40.00,?,http://www.recordholders.org/en/list/joggling.html
-05/06/2016,2016,3b Ulta (35m),No,Shires and Spires Ultra,Tim Butler,M,GBR,07:12:33.00,?,https://www.joggling.co.uk/Marathon-List
-04/06/2016,2016,3b 10km,Yes,"Moon in June, Burlington, Ontario",Gabrielle Foran,F,CAN,00:40:06.00,?,http://www.recordholders.org/en/list/joggling.html
-21/05/2016,2016,3b 5km,Yes,Blue Nose 5km,Graydon Snider,M,CAN,00:17:42.00,?,https://www.sportstats.ca/display-results.xhtml?raceid=29483
-21/05/2016,2016,3b 5km,Yes,Blue Nose 5km,Michael-Lucien Bergeron,M,CAN,00:18:55.00,?,https://www.sportstats.ca/display-results.xhtml?raceid=29483
-21/05/2016,2016,3b Half Marathon,Yes,Fargo Half Marathon,Ivan Schleppenbach,M,USA,01:40:45.00,?,https://www.mtecresults.com/runner/show?race=4076&rid=6133
-30/04/2016,2016,3b Half Marathon,Yes,"St. Jude Rock 'n Roll Half Marathon, Nashville TN",David Quint,M,USA,02:29:32.00,?,https://www.lrn.usace.army.mil/Media/News-Stories/Article/777903/employee-juggles-adversity-while-gaining-notoriety-for-charity/
-24/04/2016,2016,3b Marathon,Yes,"Zurich Marathon, Switzerland",Daniel Raum,M,AUT,03:37:17.00,?,https://services.datasport.com/2016/lauf/zuerich/alfar.htm
-08/11/2015,2015,3b Marathon,Yes,Naperville Marathon,Perry Romanowski,M,USA,03:44:46.00,?,
-01/11/2015,2015,3b Marathon,Yes,New York City Marathon,Barry Goldmeier,M,USA,05:58:38.00,?,https://www.runnersworld.com/news/a20856270/runner-dresses-as-tom-brady-at-nyc-marathon-juggles-deflated-footballs/
-18/10/2015,2015,3b Half Marathon,Yes,IMT Des Moines Half Marathon,Tyler Wishau,M,USA,01:25:10.00,?,https://www.onlineraceresults.com/race/view_race.php?race_id=48212&re_NO=e.g.%2C+1946&re_FN=tyler&re_LN=e.g.%2C+Desch&re_CITY=&re_STATE=&re_DIVISION=&submit_action=select_result&race_id=48212#results
-18/10/2015,2015,3b Marathon,Yes,"Yonkers Marathon, New York",Chris Pert,M,USA,04:10:03.00,0,https://marathonview.net/search?query=christopher%20pert
-11/10/2015,2015,3b Marathon,Yes,Chicago Marathon,Perry Romanowski,M,USA,03:38:54.00,?,https://chicago-history.r.mikatiming.com/2021/?pid=search
-27/09/2015,2015,3b Marathon,Yes,Warsaw Marathon,Mirek Urban,M,POL,04:26:03.00,?,https://nnmaratonwarszawski.com/en/aktualnosci/official-results/ https://www.joggling.pl/polskie-rekordy-i-wyniki/pozostae-polskie-wyniki-w.html
-20/09/2015,2015,3b Marathon,Yes,"Seenlandmarathon, Pleinfeld, Germany",Daniel Raum,M,AUT,03:39:56.00,?,https://seenlandmarathon2015.racepedia.de/ergebnisse/591
-06/09/2015,2015,3b 30km,No,"VanRace 30k, Vancouver",Michael-Lucien Bergeron,M,CAN,02:17:32.00,40,https://www.facebook.com/thejogglersbusker/videos/724507097694511/?app=fbl
-05/07/2015,2015,3b 5km,Yes,Guelph 5km,Gabrielle Foran,F,CAN,00:18:12.00,?,https://sites.google.com/site/guelph5kjoggling/results
-05/07/2015,2015,3b 5km,Yes,Guelph 5km,Ben Sayles,M,0,00:20:40.00,?,https://sites.google.com/site/guelph5kjoggling/results
-05/07/2015,2015,3b 5km,Yes,Guelph 5km,Mike Moore,M,USA,00:23:30.00,?,https://sites.google.com/site/guelph5kjoggling/results
-05/07/2015,2015,3b 5km,Yes,Guelph 5km,Ely Doan,M,0,00:23:52.00,?,https://sites.google.com/site/guelph5kjoggling/results
-05/07/2015,2015,3b 5km,Yes,Guelph 5km,Randy Papple,M,CAN,00:24:27.00,?,https://sites.google.com/site/guelph5kjoggling/results
-05/07/2015,2015,3b 5km,Yes,Guelph 5km,Greg Philips,M,0,00:26:12.00,?,https://sites.google.com/site/guelph5kjoggling/results
-05/07/2015,2015,3b 5km,Yes,Guelph 5km,Cameron Edmunds,M,0,00:26:27.00,?,https://sites.google.com/site/guelph5kjoggling/results
-17/05/2015,2015,3b Half Marathon,Yes,"Blue Nose Half Marathon, Halifax, Nova Scotia",Michael-Lucien Bergeron,M,CAN,01:28:28.00,?,https://www.sportstats.ca/display-results.xhtml?raceid=25949&status=results&lastname=Bergeron    https://www.facebook.com/664250217053533/posts/pfbid02AgUtA5gMLKM8xnTKednYBmKC4xshKLLrVbZs8PcD2xoLobwPAifzwaotF4kj43N2l/?app=fbl
-09/05/2015,2015,3b Half Marathon,Yes,Fargo Half Marathon,Ivan Schleppenbach,M,USA,01:37:59.00,?,https://www.mtecresults.com/runner/show?race=3013&rid=6623
-25/04/2015,2015,3b Half Marathon,Yes,"St. Jude Country Music Half Marathon, Nashville TN",David Quint,M,USA,02:25:15.00,?,"https://b5.caspio.com/dp/07f73000ef783b24a2834080a6c2      
+25/02/2020,2020,3b Marathon,Yes,Salcey Forest Marathon,Tim Butler,M,GBR,56:07.0,?,https://www.joggling.co.uk/Marathon-List
+25/01/2020,2020,3b Ultra (30m),No,Waterways 30,Tim Butler,M,GBR,36:21.0,?,https://www.joggling.co.uk/Marathon-List
+18/01/2020,2020,3b Ultra (27m),No,Pierrepont 6 Hour,Tim Butler,M,GBR,27:53.0,?,https://www.joggling.co.uk/Marathon-List
+12/01/2020,2020,3b Marathon,Yes,Langsett Marathon,Tim Butler,M,GBR,29:33.0,?,https://www.joggling.co.uk/Marathon-List
+04/01/2020,2020,3b 5km,Yes,Gloucester City Parkrun,Jordan Evans,M,GBR,20:18.0,0,https://www.strava.com/activities/2980542307
+01/01/2020,2020,3b 5km,Yes,"Faelledparken Parkrun, Copenhagen",Malachy Kelly,M,IRL,25:57.0,?,https://www.parkrun.dk/faelledparken/results/429/    https://www.facebook.com/481403242254926/posts/pfbid02KABLv52gBKhJZQ76bSg44CHmNtbLAhoz1YM2cWETaQqrXSZNDPGs1dQz7ETtByRzl/?app=fbl
+01/01/2020,2020,3b 5km,Yes,"Amager Faelled Parkrun, Copenhagen",Malachy Kelly,M,IRL,27:18.0,?,https://www.parkrun.dk/amager/results/569/   https://www.facebook.com/481403242254926/posts/pfbid02KABLv52gBKhJZQ76bSg44CHmNtbLAhoz1YM2cWETaQqrXSZNDPGs1dQz7ETtByRzl/?app=fbl
+25/12/2019,2019,3b 5km,Yes,Sligo Parkrun,Malachy Kelly,M,IRL,23:36.0,?,https://www.parkrun.ie/sligo/results/254/
+21/12/2019,2019,3b 5km,Yes,Gloucester City Parkrun,Jordan Evans,M,GBR,22:03.0,2,https://www.strava.com/activities/2971205774
+21/12/2019,2019,3b 5km,Yes,Burnham and Highbridge Parkrun,Scott Jenkins,M,GBR,23:01.0,?,
+14/12/2019,2019,3b 5km,Yes,"Killarney House Parkrun, Ireland",Malachy Kelly,M,IRL,24:20.0,?,https://www.facebook.com/killarneyhouseparkrun/videos/473825933533323/?app=fbl     https://www.parkrun.ie/killarneyhouse/results/22/
+14/12/2019,2019,3b Marathon,Yes,Elsecar Marathon,Tim Butler,M,GBR,59:36.0,?,https://www.joggling.co.uk/Marathon-List
+08/12/2019,2019,3b 10km,Yes,Bebek Etabı İstanbulu Koşuyorum,Ferda Tekgül,M,TUR,49:51.0,?,https://event.spor.istanbul/eventresults.aspx
+08/12/2019,2019,3b 15km,No,"Bruggenloop, Rotterdam",Roy van Rijn,M,NLD,45:43.0,?,https://marathonphotos.live/Event/Sports%2FNFNL%2F2019%2FBruggenloop%20Rotterdam/9626#free   https://twitter.com/royvanrijn/status/1203735661641175040?t=gGl1n9Ktl6OiiY0rAWW56w&s=19
+01/12/2019,2019,3b 5km,Yes,"Middletown, New Jersey",Karly Swaim,F,USA,32:18.0,?,https://runsignup.com/Race/Results/38943/#resultSetId-182064;page:2;perpage:100
+28/11/2019,2019,3b 5km,Yes,"New Cumberland Turkey Trot 5k, PA",Tim Ebersole,M,USA,20:41.0,?,https://falconracetiming.com/racetimes/SMT%20Turkey%20Trot%20AG%202019.htm#%201%20M
+23/11/2019,2019,3b 5km,Yes,Mallow Castle Parkrun,Malachy Kelly,M,IRL,25:06.0,?,https://www.facebook.com/481403242254926/posts/880304059031507/?mibextid=rS40aB7S9Ucbxw6v
+16/11/2019,2019,3b Marathon,Yes,Rother Valley Park Marathon,Tim Butler,M,GBR,29:54.0,?,https://www.joggling.co.uk/Marathon-List
+11/11/2019,2019,3b 10km,Yes,Olsztyn Independence Run,Jarek Widomski,M,POL,48:22.0,?,
+03/11/2019,2019,3b 15km,No,Istanbul,Ferda Tekgül,M,TUR,29:50.0,?,https://event.spor.istanbul/eventresults.aspx
+03/11/2019,2019,3b Marathon,Yes,New York City Marathon,Barak Hirschowitz,M,USA,54:10.0,?,https://www.nyrr.org/tcsnycmarathon/getinspired/photos-and-stories/2020/jack-hirschowitz
+03/11/2019,2019,3b Marathon,Yes,New York City Marathon,Jack Hirschowitz,M,USA,56:52.0,?,https://results.nyrr.org/event/M2019/finishers#search=Hirschowitz&page=1
+28/10/2019,2019,3b Mile,Yes,Time Trial (GWR),David Rush,M,USA,07:54.0,?,Blindfolded! https://www.youtube.com/watch?v=TdYXwSeqxOk
+20/10/2019,2019,3b 10km,Yes,Sarasota 10km,Barak Hirschowitz,M,USA,56:18.0,?,
+20/10/2019,2019,3b Half Marathon,Yes,Amsterdam,Necmi Oztoprak,M,TUR,50:51.0,0,https://www.instagram.com/p/B32bLemgnSv/
+13/10/2019,2019,3b 10km,Yes,Munich,Necmi Oztoprak,M,TUR,46:14.0,0,https://www.instagram.com/p/B3mGtkLAt7M/  https://www.abavent.de/anmeldeservice/muenchenmarathon2019/ergebnisse?en#3_CF93CE
+13/10/2019,2019,3b Marathon,Yes,Chicago Marathon,Perry Romanowski,M,USA,43:46.0,?,https://chicago-history.r.mikatiming.com/2021/?pid=search
+06/10/2019,2019,3b 10km,Yes,İstanbulu Koşuyorum Bakırköy Etabı 2019,Ferda Tekgül,M,TUR,55:51.0,?,https://event.spor.istanbul/eventresults.aspx
+06/10/2019,2019,3b Half Marathon,Yes,Bridlington Half Marathon,Pete Barnard,M,GBR,11:16.0,2,https://www.sportstimingsolutions.co.uk/rcd_mobile.php?id=355&bib=114
+06/10/2019,2019,3b Marathon,Yes,"3-Länder-Marathon, Lindau, Germany",Daniel Raum,M,AUT,21:37.0,?,https://bregenz.r.mikatiming.de/2019/?pid=search
+05/10/2019,2019,4b 10km,Yes,"Runinaddu, Maldives ",Michal Kapral,M,CAN,55:48.0,?,https://runningmagazine.ca/the-scene/michal-kapral-sets-worlds-first-4-ball-joggling-10k-record-in-paradise/
+28/09/2019,2019,3b 5km,Yes,Mill Race 5km,John Riden,M,USA,29:16.0,4,https://www.strava.com/activities/2746941936
+22/09/2019,2019,3b Marathon,Yes,Rutland Water Marathon,Tim Butler,M,GBR,49:25.0,?,https://www.joggling.co.uk/Marathon-List
+15/09/2019,2019,3b 10km,Yes,Tübingen Heritage Run,Peter Rottenbach,M,DEU,58:45.0,?,https://my.raceresult.com/119388/#0_E863AF 
+14/09/2019,2019,3b 10km,Yes,VI Run Grand Prix Warsaw,Jarek Widomski,M,POL,45:15.0,2,
+08/09/2019,2019,3b Half Marathon,Yes,Harrisburg Half Marathon,Tim Ebersole,M,USA,32:59.0,2,https://falconracetiming.com/racetimes/Harrisburg%20Half%20Marathon%20Overall%202019.htm
+08/09/2019,2019,3b Half Marathon,Yes,Maybank Bali Marathon,Levent Denizci,M,TUR,14:32.0,3,https://www.instagram.com/p/B2qhaW0g48r/  https://www.instagram.com/p/B2Llfk0AXco/
+01/09/2019,2019,3b Marathon,Yes,York Turbin Challenge,Tim Butler,M,GBR,55:00.0,?,https://www.joggling.co.uk/Marathon-List
+25/08/2019,2019,3b Marathon,Yes,Santa Rosa Marathon,Barak Hirschowitz,M,USA,31:11.0,?,https://marathonview.net/search?query=barak%20hirschowitz
+15/08/2019,2019,3b Half Marathon,Yes,Aleksandrow Zodzki Half Marathon,Jarek Widomski,M,POL,44:35.0,0,
+27/07/2019,2019,3b Ultra (44.9m),No,Dusk Till Dawn,Tim Butler,M,GBR,00:00.0,?,https://www.joggling.co.uk/Marathon-List
+17/07/2019,2019,3b 10km,Yes,Bungay 10km,John Jervis,M,GBR,47:42.0,7,https://www.runbritainrankings.com/results/results.aspx?meetingid=297940&event=10KMT&venue=Bungay&date=17-Jul-19
+06/07/2019,2019,3b Marathon,Yes,York Interstellar Marathon,Tim Butler,M,GBR,20:58.0,?,https://www.joggling.co.uk/Marathon-List
+27/06/2019,2019,3b 5km,Yes,"St. Peter's Fiesta 5km, Gloucester, MA",Richard Ross,M,USA,19:59.0,?,https://www.instagram.com/p/BzQTDEWhe-X/  https://newenglandruns.com/race-results/st-peters-fiesta-5k/?date=2019-06-27&result=43122&bib=ross&gender=&division=&order_by=finish_time&order=ASC
+16/06/2019,2019,3b 5km,Yes,"Evanston Race Against Hate, IL",Dean Radcliffe,M,USA,25:10.0,?,https://results.raceroster.com/v2/en-US/results/urrk4wsy39e9crfs/results?subEvent=25982&page=1&search=Dean+radcliffe
+16/06/2019,2019,3b Marathon,Yes,Bahtat Marathon,Tim Butler,M,GBR,33:23.0,?,https://www.joggling.co.uk/Marathon-List
+15/06/2019,2019,3b 13km,No,Sapanca ultra 13K,Ferda Tekgül,M,TUR,28:27.0,?,https://onedrive.live.com/?authkey=%21ADr22XJVkZDvUAU&cid=D218D0DBBD3CA6B9&id=D218D0DBBD3CA6B9%21143009&parId=D218D0DBBD3CA6B9%21188717&o=OneUp
+09/06/2019,2019,3b Half Marathon,Yes,"Dumb Dutchman Half Marathon, Reading, PA",Tim Ebersole,M,USA,38:42.0,17,https://www.pretzelcitysports.com/wp-content/uploads/2019/06/19-reading-dumb-half-res.pdf
+08/06/2019,2019,3b 5km,Yes,"Blue Nose 5k, Halifax, Nova Scotia",Michael-Lucien Bergeron,M,CAN,17:16.0,?,https://www.sportstats.ca/display-results.xhtml?raceid=100727&status=results&lastname=Bergeron    https://www.facebook.com/664250217053533/posts/pfbid02AgUtA5gMLKM8xnTKednYBmKC4xshKLLrVbZs8PcD2xoLobwPAifzwaotF4kj43N2l/?app=fbl
+02/06/2019,2019,3b Marathon,Yes,Huddersfield Marathon,Tim Butler,M,GBR,06:13.0,?,https://www.joggling.co.uk/Marathon-List  https://www.doncasterathleticclub.com/results-update-3-june-2019-huddersfield-humber-bridge-half-escape-from-gb-calderdale-way-ultra-and-parkruns/?fbclid=IwAR3YhCfSbUN5tPfdy8Hm7N_xGcg4rVoxfEO6oARGG_bbrtOh0nlvXz_T0oM
+26/05/2019,2019,3b Marathon,Yes,Winterthur Marathon,Daniel Raum,M,AUT,22:58.0,?,https://services.datasport.com/2019/lauf/winterthur/rang010.htm
+18/05/2019,2019,3b 10km,Yes,Bozcaada,Necmi Oztoprak,M,TUR,53:31.0,3,https://www.instagram.com/p/Bxmx3Zdh2P5/
+18/05/2019,2019,3b 10km,Yes,Bozcaada,Levent Denizci,M,TUR,02:16.0,2,https://www.instagram.com/p/BxmoEpphnga/
+18/05/2019,2019,3b Marathon,Yes,Fargo Marathon,Ivan Schleppenbach,M,USA,44:42.0,?,https://www.mtecresults.com/runner/show?race=8184&rid=1211
+11/05/2019,2019,3b Ultra (33m),No,Chesterfield Spire Ultra,Tim Butler,M,GBR,06:13.0,?,https://www.joggling.co.uk/Marathon-List
+05/05/2019,2019,3b Marathon,Yes,Vancouver Marathon,Nigel Wakita,M,CAN,01:12.0,6,https://www.instagram.com/p/BxGYO6IgjoJ/?hl=en
+27/04/2019,2019,3b 5km,Yes,Cardiff Parkrun,Pete Barnard,M,GBR,29:53.0,?,https://www.parkrun.org.uk/cardiff/results/594/     https://twitter.com/speirce/status/1122092919303868416
+21/04/2019,2019,3b Marathon,Yes,Northampton Chocathon,Tim Butler,M,GBR,47:09.0,?,https://www.joggling.co.uk/Marathon-List
+14/04/2019,2019,3b Marathon,Yes,Peterborough Marathon,Tim Butler,M,GBR,24:54.0,?,https://www.joggling.co.uk/Marathon-List
+13/04/2019,2019,3b Marathon,Yes,"Linz Marathon, Austria",Daniel Raum,M,AUT,14:19.0,?,https://linzmarathon.r.mikatiming.de/2019/?pid=search
+07/04/2019,2019,3b 10km,Yes,Vodafone İstanbul Yarı Maratonu 2019,Ferda Tekgül,M,TUR,06:54.0,?,https://event.spor.istanbul/eventresults.aspx
+07/04/2019,2019,3b Half Marathon,Yes,Bonn Half Marathon,Peter Meyer,M,DEU,14:57.0,4,50% 4 balls
+30/03/2019,2019,3b 5km,Yes,Leicester Victoria Parkrun,Scott Jenkins,M,GBR,25:39.0,?,
+23/03/2019,2019,3b Marathon,Yes,Yorkshire Cakeathon,Tim Butler,M,GBR,58:51.0,?,https://www.joggling.co.uk/Marathon-List
+16/03/2019,2019,3b 5km,Yes,Gloucester City Parkrun,Jordan Evans,M,GBR,20:48.0,2,https://www.strava.com/activities/2222976844
+10/03/2019,2019,3b Marathon,Yes,Cambridge Boundary Run,Tim Butler,M,GBR,53:28.0,?,https://www.joggling.co.uk/Marathon-List
+09/02/2019,2019,3b 12km,No,Manavgat ultra  12k,Ferda Tekgül,M,TUR,51:39.0,?,https://limitsensin.org/live/results/manavgatultra2019/12K
+27/01/2019,2019,3b Marathon,Yes,Celebration Orlando Marathon,Barak Hirschowitz,M,USA,08:29.0,?,https://marathonview.net/search?query=barak%20hirschowitz
+19/01/2019,2019,3b Ultra (30m),No,Pierrepont 6 Hour,Tim Butler,M,GBR,39:44.0,?,https://www.joggling.co.uk/Marathon-List
+01/01/2019,2019,3b 5km,Yes,Armley Parkrun,Ralph Kidner,M,GBR,31:01.0,?,https://www.parkrun.org.uk/armley/results/29/ https://m.facebook.com/story.php?story_fbid=pfbid0S5Y7CWHugGrM2R3UnDsNUshTjfSs29GTfhidBuUhGMNM1h6ufibYEvqhRzzmm3XFl&id=587811608285641
+28/12/2018,2018,3b Marathon,Yes,Barrow Xmas Tipple,Tim Butler,M,GBR,56:44.0,?,https://www.joggling.co.uk/Marathon-List
+17/11/2018,2018,3b Marathon,Yes,Kirkstall Abbey Marathon,Tim Butler,M,GBR,37:54.0,?,https://www.joggling.co.uk/Marathon-List
+10/11/2018,2018,3b 5km,Yes,Dinton Pastures Parkrun,Stuart Humphries,M,GBR,24:20.0,?,https://www.parkrun.org.uk/dintonpastures/results/18/   https://www.parkrun.org.uk/dintonpastures/news/2018/11/12/dinton-pastures-parkrun-18/
+04/11/2018,2018,3b 5km,Yes,Time Trial,Sterling Franklin,M,USA,19:32.0,0,https://www.youtube.com/watch?v=4pMKerapCpk
+04/11/2018,2018,3b 10km,Yes,Leeds Abbey Dash,Pete Barnard,M,GBR,59:29.0,0,https://results.sporthive.com/events/6460069711597044224/races/446670
+04/11/2018,2018,3b 10km,Yes,Leeds Abbey Dash,Ralph Kidner,M,GBR,00:29.0,4,https://results.sporthive.com/events/6460069711597044224/races/446670
+04/11/2018,2018,3b Marathon,Yes,New York City Marathon,Jack Hirschowitz,M,USA,51:10.0,?,https://results.nyrr.org/event/M2018/finishers#search=Jack%2520Hirschowitz
+21/10/2018,2018,3b Half Marathon,Yes,Toronto Waterfront Half Marathon,Michael-Lucien Bergeron,M,CAN,17:09.0,?,https://runningmagazine.ca/sections/runs-races/bergeron-breaks-half-marathon-joggling-record/
+21/10/2018,2018,3b Half Marathon,Yes,Toronto Waterfront Half Marathon,Graydon Snider,M,CAN,17:11.0,?,https://runningmagazine.ca/sections/runs-races/bergeron-breaks-half-marathon-joggling-record/
+21/10/2018,2018,3b Marathon,Yes,"Yonkers Marathon, New York",Chris Pert,M,USA,30:30.0,?,https://marathonview.net/search?query=christopher%20pert
+20/10/2018,2018,3b 5km,Yes,Trick or Trot 5km,Tyler Wishau,M,USA,21:04.0,0,https://www.facebook.com/profile/100064067107732/search/?q=joggling
+14/10/2018,2018,3b Marathon,Yes,Spires and Steeples,Tim Butler,M,GBR,33:00.0,?,https://www.joggling.co.uk/Marathon-List
+07/10/2018,2018,3b 10km,Yes,Southend 10km,Jordan Evans,M,GBR,41:20.0,?,https://www.strava.com/activities/1889442921
+07/10/2018,2018,3b Marathon,Yes,Chicago Marathon,Perry Romanowski,M,USA,45:13.0,?,https://chicago-history.r.mikatiming.com/2021/?pid=search
+07/10/2018,2018,3b Marathon,Yes,Chicago Marathon,Sarah Szefi,F,USA,02:30.0,?,https://chicago-history.r.mikatiming.com/2021/?pid=search
+30/09/2018,2018,3b Half Marathon,Yes,Cheltenham Half Marathon,Jordan Evans,M,GBR,26:55.0,?,
+29/09/2018,2018,3b Marathon,Yes,Warsaw Marathon,Jarek Widomski,M,POL,39:54.0,7,
+15/09/2018,2018,3b 5km,Yes,Dalby Forest Parkrun,Pete Barnard,M,GBR,26:24.0,?,https://www.parkrun.org.uk/dalbyforest/results/127/  https://www.parkrun.org.uk/dalbyforest/news/2018/09/23/event-127-return-of-the-joggler/
+09/09/2018,2018,3b 10km,Yes,Pied Piper 10km,Jordan Evans,M,GBR,41:53.0,?,https://www.strava.com/activities/1829732164
+02/09/2018,2018,3b Marathon,Yes,Hornsea Marathon,Tim Butler,M,GBR,22:23.0,?,https://www.joggling.co.uk/Marathon-List
+30/08/2018,2018,3b Mile,Yes,Time Trial,Scott Jenkins,M,GBR,06:58.0,0,
+19/08/2018,2018,3b 10km,Yes,"Navy 10k Race, Halifax, Nova Scotia",Michael-Lucien Bergeron,M,CAN,35:36.0,?,https://athleticsillustrated.com/michael-lucien-bergerons-ballsy-joggling-nets-him-a-world-10k-record/    https://runningmagazine.ca/the-scene/canadian-runs-5000m-joggling-world-record-of-1650/
+18/08/2018,2018,3b 5km,Yes,Frédéric Back parkrun,Graydon Snider,M,CAN,16:57.0,0,https://www.parkrun.ca/fredericback/news/2018/09/15/highlights-from-the-last-few-weeks/  https://www.parkrun.ca/fredericback/results/58/
+12/08/2018,2018,3b Marathon,Yes,Rocky Horror Tribute Marathon,Tim Butler,M,GBR,52:41.0,?,https://www.joggling.co.uk/Marathon-List
+28/07/2018,2018,3b 5km,Yes,Gloucester North Parkrun,Jordan Evans,M,GBR,21:26.0,?,https://www.strava.com/activities/1732580500
+28/07/2018,2018,3b Marathon,Yes,Dusk Till Dawn,Tim Butler,M,GBR,56:48.0,?,https://www.joggling.co.uk/Marathon-List
+04/07/2018,2018,3b 4 Mile,No,Firecracker 4,Tony Malikowski,M,USA,35:35.0,?,https://runsignup.com/Race/Results/27413#resultSetId-123798;perpage:100
+01/07/2018,2018,3b Marathon,Yes,Halifax Marathon,Tim Butler,M,GBR,48:57.0,?,https://www.joggling.co.uk/Marathon-List
+02/06/2018,2018,3b Half Marathon,Yes,Grand Teton Half Marathon,Scott Gorman,M,USA,06:35.0,?,https://www.facebook.com/photo/?fbid=10102571142247321&set=a.682390132741  https://runsignup.com/Race/Results/36796#resultSetId-118559;perpage:100
+27/05/2018,2018,3b Marathon,Yes,"Winterthur Marathon, Switzerland",Daniel Raum,M,AUT,14:19.0,?,https://services.datasport.com/2018/lauf/winterthur/alfar.htm
+20/05/2018,2018,3b Ultra (35m),No,Shires and Spires Ultra,Tim Butler,M,GBR,50:43.0,?,https://www.joggling.co.uk/Marathon-List
+19/05/2018,2018,3b 5km,Yes,"Blue Nose 5k, Halifax, Nova Scotia",Michael-Lucien Bergeron,M,CAN,17:01.0,?,https://www.sportstats.ca/display-results.xhtml?raceid=93319     https://www.facebook.com/664250217053533/posts/pfbid0219Yu1yTQzrGpqUzeYuti47oUfMr1RHohS3bhUrdxFH89RQh6iLr4qMkCR7Wacb9Rl/?app=fbl
+19/05/2018,2018,3b 5km,Yes,"Blue Nose 5k, Halifax, Nova Scotia",Bradley Fiander,M,CAN,19:44.0,?,https://www.sportstats.ca/display-results.xhtml?raceid=93319&status=results&bib=9207     https://www.facebook.com/664250217053533/posts/pfbid026Q8wfDQrDtNwPhxy9kixvJSxzPoa62mcs3kfx9te2VsD5PViKr5DnzvxC4JRf17Xl/?app=fbl
+19/05/2018,2018,3b Marathon,Yes,Fargo Marathon,Ivan Schleppenbach,M,USA,28:29.0,?,https://www.mtecresults.com/runner/show?race=6660&rid=463
+11/05/2018,2018,3b Half Marathon,Yes,Fredericton Half Marathon,Michael-Lucien Bergeron,M,CAN,20:50.0,?,https://www.saltwire.com/nova-scotia/sports/video-bergeron-combines-running-and-juggling-243982/   https://results.raceroster.com/en-CA/results/detail/chxvfrgp4wa9fz63
+10/05/2018,2018,3b Half Marathon,Yes,"Auffahrtslauf St. Gallen Half Marathon, Switzerland",Daniel Raum,M,AUT,40:20.0,?,https://my.raceresult.com/85080/#1_C8F593
+08/05/2018,2018,3b Mile,Yes,Time Trial,Zach Prescott,M,USA,04:43.0,?,https://www.runnersworld.com/runners-stories/a20732918/joggler-sets-a-world-record-in-the-mile/
+06/05/2018,2018,3b Marathon,Yes,Roche Abbey Marathon,Tim Butler,M,GBR,38:04.0,?,https://www.joggling.co.uk/Marathon-List
+05/05/2018,2018,3b 5km,Yes,Sewerby Parkrun,Pete Barnard,M,GBR,31:12.0,0,https://www.parkrun.org.uk/sewerby/results/335/ https://m.facebook.com/story.php?story_fbid=pfbid032JYDayTNJ4AKADEDA61CW5ZCboGmHMtsAA5L3YMzv1LmUPhBbvnWWBhpfbZ5REASl&id=765064822
+22/04/2018,2018,3b Marathon,Yes,"Zurich Marathon, Switzerland",Daniel Raum,M,AUT,59:46.0,?,https://services.datasport.com/2018/lauf/zuerich/alfar.htm
+22/04/2018,2018,3b Marathon,Yes,London Marathon,Tim Butler,M,GBR,13:39.0,?,https://www.joggling.co.uk/Marathon-List
+15/04/2018,2018,3b Marathon,Yes,Brighton Marathon,Jordan Evans,M,GBR,34:38.0,?,
+14/04/2018,2018,3b 5km,Yes,Kingsway Parkrun,Jordan Evans,M,GBR,19:44.0,?,https://www.strava.com/activities/1507147677
+08/04/2018,2018,3b Marathon,Yes,Bungay Marathon,Tim Butler,M,GBR,27:09.0,?,https://www.joggling.co.uk/Marathon-List
+08/04/2018,2018,3b Marathon,Yes,Rome Marathon,Jack Hirschowitz,M,USA,06:04.0,?,https://www.facebook.com/photo/?fbid=2026070107465749&set=gm.882770911894760  https://marathonview.net/search?query=jack%20hirschowitz
+02/04/2018,2018,3b Marathon,Yes,GBC Barrow Day 4,Tim Butler,M,GBR,56:48.0,?,https://www.joggling.co.uk/Marathon-List
+25/03/2018,2018,3b 50 Mile,Yes,"Charlottesville, Virginia",Rick Kwiatkowski,M,USA,53:55.0,?,https://www.guinnessworldrecords.com/world-records/fastest-50-miles-joggling
+17/03/2018,2018,3b 5km,Yes,Kilkenny Parkrun,Malachy Kelly,M,IRL,26:32.0,?,https://www.parkrun.ie/kilkenny/results/175/  https://fb.watch/lONEFREqLf/
+17/03/2018,2018,3b Half Marathon,Yes,"Wrightsville Beach Half Marathon, North Carolina",Terry Odom,M,USA,16:56.0,16,clubs http://roguerunners.org/WBhalfmarathon18.htm    https://www.wect.com/story/37755742/nc-man-completes-wrightsville-beach-half-marathon-while-juggling/
+10/03/2018,2018,3b 5km,Yes,Gloucester City Parkrun,Jordan Evans,M,GBR,18:51.0,?,https://www.strava.com/activities/1445037548  https://www.parkrun.org.uk/gloucestercity/results/2/
+04/03/2018,2018,3b Half Marathon,Yes,Paris Half Marathon,Levent Denizci,M,TUR,01:09.0,5,https://www.instagram.com/p/Bf5tx4UjS9B/
+17/12/2017,2017,3b Marathon,Yes,Newark Showground Day 2,Tim Butler,M,GBR,09:19.0,?,https://www.joggling.co.uk/Marathon-List
+16/12/2017,2017,3b Marathon,Yes,Newark Showground Day 1,Tim Butler,M,GBR,34:00.0,?,https://www.joggling.co.uk/Marathon-List
+03/12/2017,2017,3b Marathon,Yes,Christmas Marathon,Tim Butler,M,GBR,34:42.0,?,https://www.joggling.co.uk/Marathon-List
+26/11/2017,2017,3b 10km,Yes,Gloucester 10km,Jordan Evans,M,GBR,39:32.0,?,https://www.strava.com/activities/1291259819 https://www.thepowerof10.info/resultsfiles/2017/222094_7901_05122017010351_GLOS.pdf
+26/11/2017,2017,3b 10km,Yes,Doncaster 10k,Pete Barnard,M,GBR,05:33.0,0,https://racetimingsolutions.racetecresults.com/Search.aspx?CId=16269&RId=808&S=Barnard     https://www.facebook.com/765064822/posts/pfbid0omvHhgfAT2zPhZ9nX4PYSe1Sp2qJLBtZzjTyiKnuPzjy4Li2Dg3VHdMgTxGW6f4Bl/?app=fbl
+25/11/2017,2017,3b 10km,Yes,Bodrun Ultra 2017,Ferda Tekgül,M,TUR,05:58.0,?,https://onedrive.live.com/?authkey=%21AESvHE3mopXxiiM&cid=D218D0DBBD3CA6B9&id=D218D0DBBD3CA6B9%21142974&parId=D218D0DBBD3CA6B9%21170908&o=OneUp
+17/11/2017,2017,3b Marathon,Yes,Kirkstall Abbey Marathon,Tim Butler,M,GBR,55:00.0,?,https://www.joggling.co.uk/Marathon-List
+11/11/2017,2017,3b 5km,Yes,Hull Parkrun,Pete Barnard,M,GBR,30:59.0,?,https://www.parkrun.org.uk/hull/news/2017/11/13/event-404-11th-november-2017-by-claire-hughes/
+05/11/2017,2017,3b Marathon,Yes,New York City Marathon,Jack Hirschowitz,M,USA,57:36.0,?,https://results.nyrr.org/event/M2017/finishers#search=Jack%2520Hirschowitz
+22/10/2017,2017,3b Half Marathon,Yes,Stroud Half Marathon,Jordan Evans,M,GBR,30:01.0,?,https://www.strava.com/activities/1241841107
+22/10/2017,2017,3b Marathon,Yes,Ventura Marathon,Perry Romanowski,M,USA,56:34.0,?,https://marathonview.net/result/51051873
+21/10/2017,2017,3b 5km,Yes,Gloucester North Parkrun,Jordan Evans,M,GBR,21:24.0,?,https://www.strava.com/activities/1239818353
+15/10/2017,2017,3b Half Marathon,Yes,Prince Edward Island Half Marathon,Michael-Lucien Bergeron,M,CAN,21:34.0,6,https://runningmagazine.ca/sections/runs-races/michael-bergeron-2017-pei-half-marathon/     https://peiroadrunners.ca/results/2017/pei-marathon/13.1mi/
+01/10/2017,2017,3b Half Marathon,Yes,Cheltenham Half Marathon,Jordan Evans,M,GBR,32:17.0,?,https://www.strava.com/activities/1209848764
+30/09/2017,2017,3b 5km,Yes,Gloucester North Parkrun,Jordan Evans,M,GBR,19:57.0,?,https://www.strava.com/activities/1208265120
+24/09/2017,2017,3b Marathon,Yes,Nottingham Marathon,Tim Butler,M,GBR,43:42.0,?,https://www.joggling.co.uk/Marathon-List
+23/09/2017,2017,3b 5km,Yes,Kingsway Parkrun,Jordan Evans,M,GBR,18:54.0,0,https://www.strava.com/activities/1197014312
+17/09/2017,2017,3b Marathon,Yes,"Seenlandmarathon, Pleinfeld, Germany",Daniel Raum,M,AUT,37:00.0,?,https://www.nordbayern.de/region/wei%C3%9Fenburg/den-kompletten-marathon-jongliert-1.6643622?isAmp=true
+10/09/2017,2017,3b Marathon,Yes,Iceni Marathon (Thetford),Tim Butler,M,GBR,06:54.0,?,https://www.joggling.co.uk/Marathon-List
+09/09/2017,2017,3b 5km,Yes,Hadleigh Parkrun,Jordan Evans,M,GBR,21:07.0,?,https://www.parkrun.org.uk/hadleigh/news/2017/09/13/hadleigh-parkrun-45-the-parkrun-juggler-or-should-we-call-him-the-parkrun-joggler/
+02/09/2017,2017,3b 5km,Yes,Worcester Pitchcroft Parkrun,Jordan Evans,M,GBR,19:00.0,?,https://www.strava.com/activities/1163922574  https://www.parkrun.org.uk/worcesterpitchcroft/results/12/
+19/08/2017,2017,3b 5km,Yes,Cheltenham Parkrun,Jordan Evans,M,GBR,20:18.0,?,https://www.strava.com/activities/1140724011
+12/08/2017,2017,3b 5km,Yes,Sewerby Parkrun,Pete Barnard,M,GBR,35:06.0,?,https://www.parkrun.org.uk/sewerby/results/298/  https://fb.watch/lONDsC92AI/
+05/08/2017,2017,3b 5km,Yes,Tewkesbury Parkrun,Jordan Evans,M,GBR,19:43.0,?,https://www.strava.com/activities/1117927066
+30/07/2017,2017,3b 10km,Yes,Gloucester Race 4 Men,Jordan Evans,M,GBR,44:15.0,?,https://www.strava.com/activities/1108372759
+29/07/2017,2017,3b 5km,Yes,"Windsor 5k Fun Run, Nova Scotia",Bradley Fiander,M,CAN,20:45.0,?,https://results.raceroster.com/v2/en-CA/results/rvd77z5qbtrc4q3c/results?subEvent=&search=Fiander&page=1    https://www.facebook.com/513379212/posts/10155174605369213/?substory_index=652552003056853&app=fbl
+29/07/2017,2017,3b 5km,Yes,Cheltenham Parkrun,Jordan Evans,M,GBR,20:50.0,?,https://www.strava.com/activities/1106537994
+29/07/2017,2017,3b Ulta (41.7m),No,Dusk Till Dawn,Tim Butler,M,GBR,00:00.0,?,https://www.joggling.co.uk/Marathon-List
+08/07/2017,2017,3b 5km,Yes,Forest of Dean Parkrun,Jordan Evans,M,GBR,21:14.0,?,https://www.strava.com/activities/1073066127
+01/07/2017,2017,3b 5km,Yes,Hockley Woods Parkrun,Jordan Evans,M,GBR,20:54.0,?,https://www.parkrun.org.uk/hockleywoods/results/123/  https://www.strava.com/activities/1061860974
+24/06/2017,2017,3b 5km,Yes,Gloucester North Parkrun,Jordan Evans,M,GBR,21:17.0,?,https://www.strava.com/activities/1051235595
+18/06/2017,2017,3b 10km,Yes,"Running of the Balls 10k, New York",Richard Ross,M,USA,46:29.0,?,https://nycruns.com/race-results?race=the-running-of-the-balls-5k-10k-2&result=241746
+18/06/2017,2017,3b 10km,Yes,"Running of the Balls 10k, New York",Jack Hirschowitz,M,USA,00:01.0,?,https://nycruns.com/race-results?race=the-running-of-the-balls-5k-10k-2&result=241892
+17/06/2017,2017,3b 5km,Yes,Gloucester North Parkrun,Jordan Evans,M,GBR,20:39.0,?,https://www.strava.com/activities/1040339086
+10/06/2017,2017,3b 5km,Yes,Kingsway Parkrun,Jordan Evans,M,GBR,20:14.0,?,https://www.strava.com/activities/1029177556
+04/06/2017,2017,3b Ulta (35m),No,Shires and Spires Ultra,Tim Butler,M,GBR,52:16.0,?,https://www.joggling.co.uk/Marathon-List
+03/06/2017,2017,3b 5km,Yes,Kingsway Parkrun,Jordan Evans,M,GBR,21:17.0,?,https://www.strava.com/activities/1018599588
+28/05/2017,2017,3b Marathon,Yes,Edinburgh Marathon,Tim Butler,M,GBR,35:41.0,?,https://www.joggling.co.uk/Marathon-List
+27/05/2017,2017,3b 5km,Yes,Gloucester North Parkrun,Jordan Evans,M,GBR,21:41.0,?,https://www.strava.com/activities/1011523706
+20/05/2017,2017,3b 5km,Yes,"Blue Nose 5k, Halifax, Nova Scotia",Michael-Lucien Bergeron,M,CAN,17:47.0,?,https://www.sportstats.ca/display-results.xhtml?raceid=42181&status=results&lastname=Bergeron     https://www.facebook.com/664250217053533/posts/pfbid02AgUtA5gMLKM8xnTKednYBmKC4xshKLLrVbZs8PcD2xoLobwPAifzwaotF4kj43N2l/?app=fbl
+20/05/2017,2017,3b Half Marathon,Yes,Fargo Half Marathon,Ivan Schleppenbach,M,USA,39:26.0,?,https://www.mtecresults.com/runner/show?race=5201&rid=3583  https://www.inforum.com/sports/fargo-marathon-juggler-returns-to-the-half-marathon
+17/04/2017,2017,3b Marathon,Yes,Boston Marathon,Michael-Lucien Bergeron,M,CAN,13:12.0,4,
+17/04/2017,2017,3b Marathon,Yes,"Boston Marathon, Lincolnshire",Tim Butler,M,GBR,07:30.0,?,https://www.joggling.co.uk/Marathon-List
+09/04/2017,2017,3b Marathon,Yes,"Zurich Marathon, Switzerland",Daniel Raum,M,AUT,19:36.0,?,https://services.datasport.com/2017/lauf/zuerich/alfar.htm
+02/04/2017,2017,3b Half Marathon,Yes,Berlin Half Marathon,Levent Denizci,M,TUR,01:12.0,3,https://www.generali-berliner-halbmarathon.de/en/your-race/results-archive/  https://www.instagram.com/p/Bxyq8-FgTc5/
+13/03/2017,2017,3b 10km,Yes,SEDENA 10km,Jorge Vilchis,M,MEX,55:53.0,1,https://www.instagram.com/reel/BRlnTukgLnd/
+11/03/2017,2017,3b Marathon,Yes,Leeds Canel Canter,Tim Butler,M,GBR,52:38.0,?,https://www.joggling.co.uk/Marathon-List
+20/11/2016,2016,3b Marathon,Yes,Brooklyn Marathon,Chris Pert,M,USA,16:20.0,0,https://marathonview.net/search?query=christopher%20pert
+19/11/2016,2016,3b Marathon,Yes,Maravan 1,Tim Butler,M,GBR,14:35.0,?,https://www.joggling.co.uk/Marathon-List
+06/11/2016,2016,3b Marathon,Yes,New York City Marathon,Jack Hirschowitz,M,USA,53:00.0,?,https://results.nyrr.org/event/M2016/finishers#search=Jack%2520Hirschowitz
+30/10/2016,2016,3b Half Marathon,Yes,River Thames Half Marathon,Kevin Williams,M,GBR,00:12.0,7,https://www.jogglathon.co.uk/   https://www.sportsystems.co.uk/ss/results/athlete/?entId=WILLI-DHEIM-KEVNN
+23/10/2016,2016,3b 10 Mile,No,Great South Run,Kevin Williams,M,GBR,27:03.0,3,https://www.jogglathon.co.uk/  https://www.greatrun.org/results/584/8507/
+23/10/2016,2016,3b Marathon,Yes,Leicester Marathon,Tim Butler,M,GBR,27:51.0,?,https://www.joggling.co.uk/Marathon-List
+16/10/2016,2016,3b Half Marathon,Yes,Great Birmingham Run,Kevin Williams,M,GBR,58:13.0,2,https://www.jogglathon.co.uk/   https://www.greatrun.org/results/585/18760/
+12/10/2016,2016,3b 10km,Yes,Milan 10km (Dee Jay 10),Levent Denizci,M,TUR,50:38.0,0,https://www.instagram.com/p/BgVHirAgPhN/  https://www.instagram.com/p/BLc4Hh3jnwm/
+09/10/2016,2016,3b Half Marathon,Yes,Royal Parks Foundation Half Marathon,Kevin Williams,M,GBR,02:09.0,5,https://www.jogglathon.co.uk/     https://chiptiming.co.uk/events/royal-parks-foundation-half-marathon-2016/4943/
+09/10/2016,2016,3b Marathon,Yes,Chicago Marathon,Michal Kapral,M,CAN,55:25.0,0,https://chicago-history.r.mikatiming.com/2021/?pid=search
+09/10/2016,2016,3b Marathon,Yes,Chicago Marathon,Perry Romanowski,M,USA,49:14.0,?,https://chicago-history.r.mikatiming.com/2021/?pid=search
+02/10/2016,2016,3b Half Marathon,Yes,Tonbridge Half Marathon,Kevin Williams,M,GBR,10:00.0,2,https://www.jogglathon.co.uk/
+02/10/2016,2016,3b Marathon,Yes,Mablethorpe Marathon,Tim Butler,M,GBR,45:18.0,?,https://www.joggling.co.uk/Marathon-List
+18/09/2016,2016,3b Marathon,Yes,"Seenlandmarathon, Pleinfeld, Germany",Daniel Raum,M,AUT,55:31.0,?,https://seenlandmarathon2016.racepedia.de/ergebnisse/1136
+05/08/2016,2016,3b Half Marathon,Yes,Runtalya,Levent Denizci,M,TUR,12:10.0,4,https://www.instagram.com/p/BItmGofD3se/
+30/07/2016,2016,3b Mile,Yes,"IJA, El Paso, Texas",Gabrielle Foran,F,CAN,05:40.0,?,http://www.recordholders.org/en/list/joggling.html
+05/06/2016,2016,3b Ulta (35m),No,Shires and Spires Ultra,Tim Butler,M,GBR,12:33.0,?,https://www.joggling.co.uk/Marathon-List
+04/06/2016,2016,3b 10km,Yes,"Moon in June, Burlington, Ontario",Gabrielle Foran,F,CAN,40:06.0,?,http://www.recordholders.org/en/list/joggling.html
+21/05/2016,2016,3b 5km,Yes,Blue Nose 5km,Graydon Snider,M,CAN,17:42.0,?,https://www.sportstats.ca/display-results.xhtml?raceid=29483
+21/05/2016,2016,3b 5km,Yes,Blue Nose 5km,Michael-Lucien Bergeron,M,CAN,18:55.0,?,https://www.sportstats.ca/display-results.xhtml?raceid=29483
+21/05/2016,2016,3b Half Marathon,Yes,Fargo Half Marathon,Ivan Schleppenbach,M,USA,40:45.0,?,https://www.mtecresults.com/runner/show?race=4076&rid=6133
+30/04/2016,2016,3b Half Marathon,Yes,"St. Jude Rock 'n Roll Half Marathon, Nashville TN",David Quint,M,USA,29:32.0,?,https://www.lrn.usace.army.mil/Media/News-Stories/Article/777903/employee-juggles-adversity-while-gaining-notoriety-for-charity/
+24/04/2016,2016,3b Marathon,Yes,"Zurich Marathon, Switzerland",Daniel Raum,M,AUT,37:17.0,?,https://services.datasport.com/2016/lauf/zuerich/alfar.htm
+08/11/2015,2015,3b Marathon,Yes,Naperville Marathon,Perry Romanowski,M,USA,44:46.0,?,
+01/11/2015,2015,3b Marathon,Yes,New York City Marathon,Barry Goldmeier,M,USA,58:38.0,?,https://www.runnersworld.com/news/a20856270/runner-dresses-as-tom-brady-at-nyc-marathon-juggles-deflated-footballs/
+18/10/2015,2015,3b Half Marathon,Yes,IMT Des Moines Half Marathon,Tyler Wishau,M,USA,25:10.0,?,https://www.onlineraceresults.com/race/view_race.php?race_id=48212&re_NO=e.g.%2C+1946&re_FN=tyler&re_LN=e.g.%2C+Desch&re_CITY=&re_STATE=&re_DIVISION=&submit_action=select_result&race_id=48212#results
+18/10/2015,2015,3b Marathon,Yes,"Yonkers Marathon, New York",Chris Pert,M,USA,10:03.0,0,https://marathonview.net/search?query=christopher%20pert
+11/10/2015,2015,3b Marathon,Yes,Chicago Marathon,Perry Romanowski,M,USA,38:54.0,?,https://chicago-history.r.mikatiming.com/2021/?pid=search
+27/09/2015,2015,3b Marathon,Yes,Warsaw Marathon,Mirek Urban,M,POL,26:03.0,?,https://nnmaratonwarszawski.com/en/aktualnosci/official-results/ https://www.joggling.pl/polskie-rekordy-i-wyniki/pozostae-polskie-wyniki-w.html
+20/09/2015,2015,3b Marathon,Yes,"Seenlandmarathon, Pleinfeld, Germany",Daniel Raum,M,AUT,39:56.0,?,https://seenlandmarathon2015.racepedia.de/ergebnisse/591
+06/09/2015,2015,3b 30km,No,"VanRace 30k, Vancouver",Michael-Lucien Bergeron,M,CAN,17:32.0,40,https://www.facebook.com/thejogglersbusker/videos/724507097694511/?app=fbl
+05/07/2015,2015,3b 5km,Yes,Guelph 5km,Gabrielle Foran,F,CAN,18:12.0,?,https://sites.google.com/site/guelph5kjoggling/results
+05/07/2015,2015,3b 5km,Yes,Guelph 5km,Ben Sayles,M,0,20:40.0,?,https://sites.google.com/site/guelph5kjoggling/results
+05/07/2015,2015,3b 5km,Yes,Guelph 5km,Mike Moore,M,USA,23:30.0,?,https://sites.google.com/site/guelph5kjoggling/results
+05/07/2015,2015,3b 5km,Yes,Guelph 5km,Ely Doan,M,0,23:52.0,?,https://sites.google.com/site/guelph5kjoggling/results
+05/07/2015,2015,3b 5km,Yes,Guelph 5km,Randy Papple,M,CAN,24:27.0,?,https://sites.google.com/site/guelph5kjoggling/results
+05/07/2015,2015,3b 5km,Yes,Guelph 5km,Greg Philips,M,0,26:12.0,?,https://sites.google.com/site/guelph5kjoggling/results
+05/07/2015,2015,3b 5km,Yes,Guelph 5km,Cameron Edmunds,M,0,26:27.0,?,https://sites.google.com/site/guelph5kjoggling/results
+17/05/2015,2015,3b Half Marathon,Yes,"Blue Nose Half Marathon, Halifax, Nova Scotia",Michael-Lucien Bergeron,M,CAN,28:28.0,?,https://www.sportstats.ca/display-results.xhtml?raceid=25949&status=results&lastname=Bergeron    https://www.facebook.com/664250217053533/posts/pfbid02AgUtA5gMLKM8xnTKednYBmKC4xshKLLrVbZs8PcD2xoLobwPAifzwaotF4kj43N2l/?app=fbl
+09/05/2015,2015,3b Half Marathon,Yes,Fargo Half Marathon,Ivan Schleppenbach,M,USA,37:59.0,?,https://www.mtecresults.com/runner/show?race=3013&rid=6623
+25/04/2015,2015,3b Half Marathon,Yes,"St. Jude Country Music Half Marathon, Nashville TN",David Quint,M,USA,25:15.0,?,"https://b5.caspio.com/dp/07f73000ef783b24a2834080a6c2      
     https://eu.tennessean.com/story/sports/2015/02/28/running-juggler-plans-return-half-marathon/24206411/"
-11/01/2015,2015,5b Marathon,Yes,"Disney Marathon, Orlando, FL",Barry Goldmeier,M,USA,06:09:31.00,?,http://www.marathonguide.com/results/browse.cfm?MIDD=481150111&Gen=B&Begin=13321&End=13420&Max=19959
-16/11/2014,2014,3b Marathon,Yes,Istanbul Marathon,Levent Denizci,M,TUR,04:28:48.00,11,https://www.instagram.com/p/B8fnCXJAdqf/?hl=en  https://marathonview.net/search?query=levent%20denizci  https://www.instagram.com/p/BI34IF9jS2e/
-02/11/2014,2014,3b Marathon,Yes,New York City Marathon,Jack Hirschowitz,M,USA,04:41:49.00,?,https://results.nyrr.org/event/M2014/finishers#search=Jack%2520Hirschowitz
-19/10/2014,2014,3b Half Marathon,Yes,Toronto Waterfront Half Marathon,Michal Kapral,M,CAN,01:20:40.00,?,
-12/10/2014,2014,3b Marathon,Yes,Chicago Marathon,Perry Romanowski,M,USA,03:40:45.00,?,https://chicago-history.r.mikatiming.com/2021/?pid=search
-28/09/2014,2014,3b Marathon,Yes,"Yonkers Marathon, New York",Chris Pert,M,USA,03:40:40.00,0,https://marathonview.net/search?query=christopher%20pert
-21/06/2014,2014,3b 5km,Yes,"Bangor Parkrun, Northern Ireland",Nathan Agnew,M,GBR,00:27:43.00,?,https://www.parkrun.org.uk/bangor/results/13/ https://www.parkrun.org.uk/bangor/news/2014/06/24/parkrun-achieves-over-2600-runners-200-volunteers/
-21/06/2014,2014,3b Half Marathon,Yes,Garry Bjorklund Half Marathon,Ivan Schleppenbach,M,USA,01:36:15.00,?,https://www.mtecresults.com/runner/show?race=2165&rid=11928
-08/06/2014,2014,3b 5km,Yes,"Rocky Neck 5k, Gloucester, MA",Richard Ross,M,USA,00:20:27.00,?,https://goodmorninggloucester.files.wordpress.com/2014/06/image25.png     https://youtu.be/GoE4pZ39SAY
-10/05/2014,2014,3b Half Marathon,Yes,Fargo Half Marathon,Ivan Schleppenbach,M,USA,01:38:58.00,?,https://www.mtecresults.com/runner/show?race=2183&rid=8438
-06/04/2014,2014,3b 5km,Yes,"CoDependency 5k, Cooper River Park",Dana Giuglielmo,F,USA,00:20:40.00,3,https://tomahawktiming.com/road-races/2014-season/46-codependency-5k-cooper-river/  https://medium.com/the-moorestown-sun/dana-guglielmo-breaks-guinness-world-record-for-joggling-8f1a107d5774
-06/04/2014,2014,3b Marathon,Yes,Brighton Marathon,Kevin Williams,M,GBR,04:38:18.00,?,https://www.theargus.co.uk/news/11010177.brighton-man-to-run-half-marathon-while-juggling-after-recovering-from-brain-injury/?fbclid=IwAR1USEy4inlcpMOKmdBCvst5ie4hlTLXAmXm0OyXbXI8X3sHv9V34gs7V68  https://marathonview.net/search?query=kevin%20williams
-28/02/2014,2014,3b Marathon,Yes,Tel Aviv Marathon,Shahar Cohen,M,ISR,04:25:17.00,?,https://marathonview.net/search?query=Shahar%20Cohen  https://www.israel21c.org/israeli-juggler-sets-new-record-at-the-sea-of-galilee/
-17/11/2013,2013,3b Marathon,Yes,Brooklyn Marathon,Chris Pert,M,USA,03:52:33.00,2,https://marathonview.net/search?query=christopher%20pert
-03/11/2013,2013,3b Marathon,Yes,New York City Marathon,Jack Hirschowitz,M,USA,04:42:07.00,?,https://results.nyrr.org/event/40/finishers#search=Jack%2520Hirschowitz
-13/10/2013,2013,3b Marathon,Yes,Chicago Marathon,Perry Romanowski,M,USA,03:42:23.00,?,https://chicago-history.r.mikatiming.com/2021/?pid=search
-29/09/2013,2013,3b Marathon,Yes,"Yonkers Marathon, New York",Chris Pert,M,USA,03:51:43.00,4,https://acrotrekker.wordpress.com/tag/christopher-pert-joggler/
-22/09/2013,2013,3b Marathon,Yes,Quad Cities Marathon,Joe Salter,M,USA,05:51:25.00,?,Backwards. https://www.guinnessworldrecords.com/world-records/100547-fastest-marathon-joggling-backwards
-22/06/2013,2013,3b Half Marathon,Yes,Garry Bjorklund Half Marathon,Ivan Schleppenbach,M,USA,01:41:10.00,?,https://www.mtecresults.com/runner/show?race=1394&rid=13151
-18/05/2013,2013,3b Half Marathon,Yes,Fargo Half Marathon,Ivan Schleppenbach,M,USA,01:47:04.00,?,https://www.mtecresults.com/runner/show?race=1386&rid=6886
-15/05/2013,2013,3b Mile,Yes,Time Trial,Emily Beaver,F,USA,00:05:58.00,?,https://missouristatebears.com/news/2013/5/15/Emily_Beaver_Sets_World_Record_for_Joggling https://www.guinnessworldrecords.com/world-records/fastest-mile-joggling-with-three-objects-women
-05/05/2013,2013,3b Marathon,Yes,"Flying Pig Marathon, Cincinnati",Perry Romanowski,M,USA,03:46:34.00,?,https://marathonview.net/result/42981151
-07/04/2013,2013,3b Marathon,Yes,Paris Marathon,Richard Ross,M,USA,04:00:43.00,?,https://marathonview.net/result/66848234
-07/10/2012,2012,3b Marathon,Yes,"Trapline Marathon, Labrador, Newfoundland",Michal Kapral,M,CAN,02:59:32.00,?,https://www.nlaa.ca/results/rr/2012/20121007traplinemarathon.php
-07/10/2012,2012,3b Marathon,Yes,Chicago Marathon,Perry Romanowski,M,USA,03:40:50.00,?,https://chicago-history.r.mikatiming.com/2021/?pid=search
-13/08/2012,2012,3b Mile,Yes,"Pride Stadium, Clio MI",Riley McLincha,M,USA,00:08:44.00,0,https://recordsetter.com/world-record/run-mile-while-dribbling-three-basketballs/17315?autoplay=false
-27/07/2012,2012,5b Mile,Yes,Time Trial,Matthew Feldman,M,USA,00:06:33.00,?,
-23/06/2012,2012,3b 5km,Yes,"Fishers Freedom 5km, Indiana",Bob Evans,M,USA,00:16:34.00,?,https://www.onlineraceresults.com/race/view_race.php?race_id=25925&num=15&split=TIME&submit_action=Refresh+Leaders#racetop
-23/06/2012,2012,3b 5km,Yes,"Fishers Freedom 5km, Indiana",Trish Evans,F,USA,00:20:10.00,?,https://www.onlineraceresults.com/race/view_race.php?race_id=25925&num=15&split=TIME&submit_action=Refresh+Leaders#racetop
-16/04/2012,2012,3b Marathon,Yes,Boston Marathon,Tom Gounley,M,USA,03:52:33.00,?,http://registration.baa.org/2012/cf/public/iframe_ResultsSearch.cfm?mode=results  https://www.youtube.com/watch?v=LYoont-ebxA
-04/03/2012,2012,3b 5km,Yes,"Super Kids Sunday 5k, Long Beach, California",Bob Evans,M,USA,00:16:42.00,?,https://thejoggler.blogspot.com/2012/03/bob-evans-lowers-5k-joggling-record-to.html
-18/02/2012,2012,3b 5km,Yes,Highbury Fields Parkrun,Ralph Kidner,M,GBR,00:25:37.00,?,https://www.parkrun.org.uk/highburyfields/results/15/
-16/11/2011,2011,3b Half Marathon,Yes,"Des Moines Half Marathon, Iowa",Tyler Wishau,M,USA,01:25:45.00,?,https://www.onlineraceresults.com/race/view_race.php?race_id=21745&re_NO=e.g.%2C+1946&re_FN=e.g.%2C+Joe&re_LN=Wishau&re_CITY=&re_STATE=&re_DIVISION=&submit_action=select_result&race_id=21745#results      https://www.dmu.edu/blog/2012/03/joggler-juggles-more-than-medical-school/
-12/11/2011,2011,3b 10km,Yes,"Mandarin Run, Jacksonville, Florida",Bob Evans,M,USA,00:35:41.00,?,http://1stplacesports.com/man11gradedres.htm
-12/11/2011,2011,3b 10km,Yes,"Mandarin Run, Jacksonville, Florida",Trish Evans,F,USA,00:42:58.00,?,http://www.recordholders.org/en/list/joggling.html
-12/11/2011,2011,3b Marathon,Yes,SunTrust Richmond (Virginia) Marathon,Jesse Joyner,M,USA,05:48:17.00,4,https://www.trackshackresults.com/richmond/results/2011/mar_results.php?Link=5&Type=3&LName=Joyner&FName=Jesse&City=&State=&Country=
-06/11/2011,2011,3b Marathon,Yes,New York City Marathon,Jack Hirschowitz,M,USA,04:43:53.00,?,http://www.marathonguide.com/results/search.cfm
-29/10/2011,2011,3b 5km,Yes,"Race for the Cure in Nashville, Tennessee",Bob Evans,M,USA,00:16:51.00,?,https://www.prweb.com/releases/catchitearly/joggling-world-record/prweb8929941.htm
-09/10/2011,2011,3b Marathon,Yes,Chicago Marathon,Perry Romanowski,M,USA,03:35:58.00,?,https://chicago-history.r.mikatiming.com/2021/?pid=search
-28/08/2011,2011,3b Ulta (57m),No,Boston 12 Hour Race,Tim Butler,M,GBR,12:00:00.00,?,https://www.joggling.co.uk/Marathon-List
-20/07/2011,2011,3b 5km,Yes,"IJA, Rochester",Charles Schweitzer,M,USA,00:17:57.00,?,https://dev.juggle.org/history/champs/champs2011.php
-20/07/2011,2011,3b 5km,Yes,"IJA, Rochester",Tyler Wishau,M,USA,00:18:38.00,?,https://dev.juggle.org/history/champs/champs2011.php
-20/07/2011,2011,3b 5km,Yes,"IJA, Rochester",Bob Evans,M,USA,00:19:01.00,?,https://dev.juggle.org/history/champs/champs2011.php
-20/07/2011,2011,3b 5km,Yes,"IJA, Rochester",Billy Watson,M,0,00:20:00.00,?,https://dev.juggle.org/history/champs/champs2011.php
-20/07/2011,2011,3b 5km,Yes,"IJA, Rochester",Chris Merra,M,0,00:21:41.00,?,https://dev.juggle.org/history/champs/champs2011.php
-20/07/2011,2011,3b 5km,Yes,"IJA, Rochester",Trish Evans,F,USA,00:21:46.00,?,https://dev.juggle.org/history/champs/champs2011.php
-20/07/2011,2011,3b 5km,Yes,"IJA, Rochester",John Kilgust,M,0,00:27:18.00,?,https://dev.juggle.org/history/champs/champs2011.php
-20/07/2011,2011,3b 5km,Yes,"IJA, Rochester",Dean Bennett,M,0,00:28:54.00,?,https://dev.juggle.org/history/champs/champs2011.php
-20/07/2011,2011,3b 5km,Yes,"IJA, Rochester",Nathan Wakefield,M,0,00:29:28.00,?,https://dev.juggle.org/history/champs/champs2011.php
-24/05/2011,2011,5b 5km,Yes,Time Trial,Matthew Feldman,M,USA,00:27:06.00,?,
-22/05/2011,2011,3b Half Marathon,Yes,Edinburgh Half Marathon,Steve Portwine,M,GBR,02:04:03.00,6,https://www.podiumrunner.com/events/the-tale-of-the-scottish-joggler/  https://www.getreading.co.uk/news/local-news/woodley-man-steve-portwine-juggle-4214204
-22/05/2011,2011,3b Marathon,Yes,Edinburgh Marathon,Ralph Kidner,M,GBR,04:37:31.00,48,https://www.edinburghmarathon.com/results?name=ralph+kidner&running_number=&event=28&gender=&age_category=
-24/04/2011,2011,3b Marathon,Yes,London Marathon,Tim Butler,M,GBR,05:06:20.00,?,https://www.joggling.co.uk/Marathon-List
-17/04/2011,2011,3c Marathon,No,London Marathon,Colin Francome,M,GBR,07:32:23.00,?,https://www.justgiving.com/fundraising/colinfrancome https://marathonview.net/search?query=colin%20francome
-10/04/2011,2011,3b Marathon,Yes,Paris Marathon,Perry Romanowski,M,USA,03:58:05.00,?,https://marathonview.net/result/43416935
-29/01/2011,2011,3b 50 Mile,Yes,Yorkshire Frostbite 50,Tim Butler,M,GBR,13:34:00.00,?,https://www.joggling.co.uk/Marathon-List
-07/11/2010,2010,3b Marathon,Yes,Rutland Water Marathon,Tim Butler,M,GBR,04:34:19.00,?,https://www.joggling.co.uk/Marathon-List
-10/10/2010,2010,4b Half Marathon,No,Munich Half Marathon,Peter Meyer,M,DEU,02:21:07.00,15,99% 4 balls - this is close enough! https://muenchen.r.mikatiming.de/2010/?pid=search  http://home.mnet-online.de/joggling/aboutme_d.htm
-10/10/2010,2010,3b Marathon,Yes,Chicago Marathon,Perry Romanowski,M,USA,03:38:08.00,?,https://chicago-history.r.mikatiming.com/2021/?pid=search
-10/10/2010,2010,5b Marathon,Yes,Chicago Marathon,Barry Goldmeier,M,USA,05:51:41.00,?,http://www.marathonguide.com/results/browse.cfm?MIDD=67101010&Gen=B&Begin=31706&End=31805&Max=36159
-08/08/2010,2010,3c Half Marathon,Yes,Newark Half Marathon,Tim Butler,M,GBR,02:24:00.00,?,https://www.youtube.com/watch?v=K0y6jjFVx7o  https://www.facebook.com/photo/?fbid=1467928150956&set=a.1200853594259
-23/07/2010,2010,3b Ulta (70m),No,Grimsthorpe Ultramarathon,Tim Butler,M,GBR,20:28:00.00,?,https://www.joggling.co.uk/Marathon-List
-24/04/2010,2010,3b Marathon,Yes,Nashville Country Music Marathon,Perry Romanowski,M,USA,03:48:25.00,?,
-06/12/2009,2009,3b Marathon,Yes,Rock 'n' Roll Las Vegas,Perry Romanowski,M,USA,04:08:48.00,?,
-22/11/2009,2009,3b Marathon,Yes,Philadelphia Marathon,Perry Romanowski,M,USA,03:27:29.00,?,https://marathonview.net/result/60673065
-22/11/2009,2009,3b Marathon,Yes,Philadelphia Marathon,Joe Salter,M,USA,03:31:11.00,?,
-22/11/2009,2009,3b Marathon,Yes,Philadelphia Marathon,Barry Goldmeier,M,USA,05:53:46.00,?,https://marathonview.net/search?query=Barry%20Goldmeier  https://www.facebook.com/photo/?fbid=1770227386337053&set=gm.717510868420766
-18/10/2009,2009,3b Marathon,Yes,Spires and Steeples,Tim Butler,M,GBR,04:35:16.00,?,https://www.joggling.co.uk/Marathon-List
-11/10/2009,2009,3b Marathon,Yes,Munich Marathon,Peter Meyer,M,DEU,04:28:54.00,12,80% with 4 balls. https://marathonview.net/search?query=peter%20meyer  http://home.mnet-online.de/joggling/aboutme_d.htm
-26/09/2009,2009,3b Marathon,Yes,Akron Marathon,David Livingston,M,USA,03:28:56.00,?,https://eu.beaconjournal.com/story/news/local/2015/09/24/wooster-runner-hopes-to-set/10301568007/  https://marathonview.net/search?query=david%20livingston
-14/07/2009,2009,3b 5km,Yes,"IJA, Winston-Salem",Tyler Wishau,M,USA,00:18:47.00,?,https://dev.juggle.org/history/champs/champs2009.php
-14/07/2009,2009,3b 5km,Yes,"IJA, Winston-Salem",Chuck Hawley,M,0,00:23:04.00,?,https://dev.juggle.org/history/champs/champs2009.php
-14/07/2009,2009,3b 5km,Yes,"IJA, Winston-Salem",John Clayton,M,0,00:23:50.00,?,https://dev.juggle.org/history/champs/champs2009.php
-14/07/2009,2009,3b 5km,Yes,"IJA, Winston-Salem",Kurt Siefken,M,0,00:25:52.00,?,https://dev.juggle.org/history/champs/champs2009.php
-14/07/2009,2009,3b 5km,Yes,"IJA, Winston-Salem",Andrew Swan,M,0,00:30:52.00,?,https://dev.juggle.org/history/champs/champs2009.php
-14/07/2009,2009,3b 5km,Yes,"IJA, Winston-Salem",Jack Hirschowitz,M,USA,00:30:55.00,?,https://dev.juggle.org/history/champs/champs2009.php
-14/07/2009,2009,3b 5km,Yes,"IJA, Winston-Salem",Andrew Ruiz,M,0,00:32:33.00,?,https://dev.juggle.org/history/champs/champs2009.php
-14/07/2009,2009,3b 5km,Yes,"IJA, Winston-Salem",Quentin Dombro,M,0,00:36:30.00,?,https://dev.juggle.org/history/champs/champs2009.php
-12/07/2009,2009,3b 10km,Yes,"Graves Park, Sheffield",Ralph Kidner,M,GBR,01:03:30.00,6,https://www.facebook.com/photo/?fbid=1193986171276&set=a.1149082808720 & Facebook message
-12/07/2009,2009,3b 10km,Yes,"Graves Park, Sheffield",Tim Butler,M,GBR,01:03:30.00,2,https://www.facebook.com/photo/?fbid=1193986171276&set=a.1149082808720 & Facebook message
-21/06/2009,2009,3b 10km,Yes,Leeds 10km,Ralph Kidner,M,GBR,01:09:27.00,10,https://www.justgiving.com/fundraising/ralphybabe
-06/06/2009,2009,3b Marathon,Yes,"Sunburst Marathon, South Bend",Perry Romanowski,M,USA,03:21:38.00,?,
-19/04/2009,2009,3b Half Marathon,Yes,Montreal Half-Marathon,Michal Kapral,M,CAN,01:23:49.00,2,http://thejoggler.blogspot.com/2009/04/half-marathon-joggling-record.html
-11/01/2009,2009,3b Marathon,Yes,"Disney Marathon, Orlando, FL",Jeff Civillico,M,USA,04:24:16.00,?,https://jeffcivillico.com/joggling-disney-marathon/
-19/10/2008,2008,3b Marathon,Yes,Spires and Steeples,Tim Butler,M,GBR,05:39:40.00,?,https://www.joggling.co.uk/Marathon-List
-12/10/2008,2008,3b Marathon,Yes,Victoria BC Marathon,Michal Kapral,M,CAN,03:12:05.00,?,
-12/10/2008,2008,3b Marathon,Yes,Chicago Marathon,Perry Romanowski,M,USA,03:39:36.00,?,https://chicago-history.r.mikatiming.com/2021/?pid=search
-29/08/2008,2008,3b 5km,Yes,Canadian Joggle Off,Simon Hodge,M,CAN,00:17:04.00,5,https://thejoggler.blogspot.com/2008/08/canadian-running-magazine-5k-joggle-off.html
-29/08/2008,2008,3b 5km,Yes,Canadian Joggle Off,Michal Kapral,M,CAN,00:17:05.00,0,https://thejoggler.blogspot.com/2008/08/canadian-running-magazine-5k-joggle-off.html
-15/07/2008,2008,3b 5km,Yes,"IJA, Kentucky",Perry Romanowski,M,USA,00:21:50.00,?,https://dev.juggle.org/history/champs/champs2008.php
-15/07/2008,2008,3b 5km,Yes,"IJA, Kentucky",Jesse Joyner,M,USA,00:24:24.00,?,https://dev.juggle.org/history/champs/champs2008.php
-15/07/2008,2008,3b 5km,Yes,"IJA, Kentucky",Gus Tate,M,USA,00:24:31.00,?,https://dev.juggle.org/history/champs/champs2008.php
-15/07/2008,2008,3b 5km,Yes,"IJA, Kentucky",Danny Tomaro,M,0,00:26:07.00,?,https://dev.juggle.org/history/champs/champs2008.php
-15/07/2008,2008,3b 5km,Yes,"IJA, Kentucky",Andrew Swan,M,0,00:28:03.00,?,https://dev.juggle.org/history/champs/champs2008.php
-15/07/2008,2008,3b 5km,Yes,"IJA, Kentucky",Tom McClintock,M,0,00:29:20.00,?,https://dev.juggle.org/history/champs/champs2008.php
-22/06/2008,2008,3b 10km,Yes,Leeds 10km,Ralph Kidner,M,GBR,01:12:00.00,82,https://www.facebook.com/photo/?fbid=10231140425355467
-13/04/2008,2008,3b Marathon,Yes,London Marathon,Perry Romanowski,M,USA,03:35:36.00,?,https://marathonview.net/result/45354889
-14/10/2007,2007,3b Marathon,Yes,Munich Marathon,Peter Meyer,M,DEU,04:10:07.00,1,https://marathonview.net/search?query=peter%20meyer  http://home.mnet-online.de/joggling/aboutme_d.htm
-07/10/2007,2007,3b Marathon,Yes,Chicago Marathon,Perry Romanowski,M,USA,03:59:00.00,?,https://chicago-history.r.mikatiming.com/2021/?pid=search
-30/09/2007,2007,3b Marathon,Yes,Toronto Waterfront Marathon,Michal Kapral,M,CAN,02:50:12.00,2,
-17/07/2007,2007,3b 5km,Yes,"IJA, Winston-Salem",Christoph Mitasch,M,0,00:22:27.00,?,https://dev.juggle.org/history/champs/champs2007.php
-17/07/2007,2007,3b 5km,Yes,"IJA, Winston-Salem",Greg Warrington,M,0,00:24:34.00,?,https://dev.juggle.org/history/champs/champs2007.php
-17/07/2007,2007,3b 5km,Yes,"IJA, Winston-Salem",Andrew Perrin,M,0,00:25:46.00,?,https://dev.juggle.org/history/champs/champs2007.php
-17/07/2007,2007,3b 5km,Yes,"IJA, Winston-Salem",Terry Odom,M,USA,00:29:33.00,?,https://dev.juggle.org/history/champs/champs2007.php
-17/07/2007,2007,3b 5km,Yes,"IJA, Winston-Salem",Jack Hirschowitz,M,USA,00:32:50.00,?,https://dev.juggle.org/history/champs/champs2007.php
-17/07/2007,2007,5b 5km,Yes,"IJA, Winston-Salem",Barry Goldmeier,M,USA,00:38:58.00,?,https://dev.juggle.org/history/champs/champs2007.php
-17/06/2007,2007,3b Marathon,Yes,Fuerth Marathon,Ingbert Bittel,M,DEU,04:57:25.00,?,https://www.trackmyrace.com/en/running/event-zone/event/jahrtausend-marathon-fuerth/results/marathon/   https://www.teambittel.de/team/veranstaltungen_2007/20070617_fuerth.htm
-29/04/2007,2007,3b 5km,Yes,"Limestone 5K, Kingston, Ontario",Travis Saunders,M,CAN,00:17:05.00,?,https://thejoggler.blogspot.com/2007/05/saunders-just-misses-5k-joggling-record.html
-21/04/2007,2007,3b Marathon,Yes,Salt Lake City Marathon,Michal Kapral,M,CAN,02:53:28.00,4,
-21/04/2007,2007,3b Marathon,Yes,Salt Lake City Marathon,Zach Warren,M,USA,02:57:02.00,?,
-02/04/2007,2007,3b 10km,Yes,Lincoln 10km,Tim Butler,M,GBR,00:47:01.00,?,
-25/03/2007,2007,3b 30km,No,"Around The Bay 30k, Hamilton, Canada",Michal Kapral,M,CAN,01:54:44.00,4,https://thejoggler.blogspot.com/2007/03/joggling-around-bay.html      https://www.sportstats.ca/display-results.xhtml?raceid=8080&bib=15
-19/11/2006,2006,3b Marathon,Yes,Philadelphia Marathon,Zach Warren,M,USA,02:52:15.00,?,
-05/11/2006,2006,3b Marathon,Yes,New York City Marathon,Jonas Eberlein,M,DEU,05:13:31.00,?,https://marathonview.net/search?query=Jonas%20Eberlein  https://www.justyouraveragejoggler.com/jonas-eberlein-world-traveling-adventure-joggler/
-22/10/2006,2006,3b Marathon,Yes,Chicago Marathon,Perry Romanowski,M,USA,03:24:46.00,?,https://chicago-history.r.mikatiming.com/2021/?pid=search
-24/09/2006,2006,3b Marathon,Yes,Toronto Waterfront Marathon,Michal Kapral,M,CAN,02:57:44.00,8,
-24/09/2006,2006,3b Marathon,Yes,Toronto Waterfront Marathon,Perry Romanowski,M,USA,03:28:54.00,?,https://marathonview.net/result/53088739
-10/09/2006,2006,3b 10km,Yes,Toronto Island Run,Michal Kapral,M,CAN,00:36:27.00,?,
-18/07/2006,2006,3b 5km,Yes,"IJA, Portland, Oregon",Tosch Roy,M,0,00:20:01.00,?,https://dev.juggle.org/history/champs/champs2006.php
-18/07/2006,2006,3b 5km,Yes,"IJA, Portland, Oregon",Kyle Barrett,M,0,00:21:25.00,?,https://dev.juggle.org/history/champs/champs2006.php
-18/07/2006,2006,3b 5km,Yes,"IJA, Portland, Oregon",Danny Tomaro,M,0,00:25:27.00,?,https://dev.juggle.org/history/champs/champs2006.php
-18/07/2006,2006,3b 5km,Yes,"IJA, Portland, Oregon",Tom McClintock,M,0,00:27:53.00,?,https://dev.juggle.org/history/champs/champs2006.php
-18/07/2006,2006,3b 5km,Yes,"IJA, Portland, Oregon",Dean Bennett,M,0,00:28:30.00,?,https://dev.juggle.org/history/champs/champs2006.php
-18/07/2006,2006,3b 5km,Yes,"IJA, Portland, Oregon",Dorothy Finnigan,F,0,00:36:11.00,?,https://dev.juggle.org/history/champs/champs2006.php
-28/05/2006,2006,3b Marathon,Yes,Madison Marathon,Perry Romanowski,M,USA,03:56:56.00,?,
-21/05/2006,2006,3b Marathon,Yes,Heilbronner Trollinger Marathon,Ingbert Bittel,M,DEU,05:03:18.00,?,https://www.teambittel.de/team/veranstaltungen_2007/20070617_fuerth.htm  https://marathonview.net/search?query=Ingbert%20Bittel
-17/04/2006,2006,3b Marathon,Yes,Boston Marathon,Zach Warren,M,USA,02:58:23.00,?,
-17/04/2006,2006,3b Marathon,Yes,Boston Marathon,Michal Kapral,M,CAN,03:06:45.00,14,
-20/11/2005,2005,3b Marathon,Yes,Philadelphia Marathon,Zach Warren,M,USA,03:07:05.00,?,https://www.thecrimson.com/article/2005/11/30/marathon-man-grad-student-keeps-balls/
-06/11/2005,2005,3b Marathon,Yes,New York City Marathon,Perry Romanowski,M,USA,03:58:10.00,?,https://marathonview.net/result/31146807
-09/10/2005,2005,3b Marathon,Yes,Chicago Marathon,Perry Romanowski,M,USA,03:22:54.00,?,https://chicago-history.r.mikatiming.com/2021/?pid=search
-25/09/2005,2005,3b Marathon,Yes,Toronto Waterfront Marathon,Michal Kapral,M,CAN,03:07:46.00,20,
-19/07/2005,2005,3b 5km,Yes,"IJA, Davenport, Iowa",Danny Tomaro,M,0,00:26:46.00,?,https://dev.juggle.org/history/champs/champs2005.php
-19/07/2005,2005,3b 5km,Yes,"IJA, Davenport, Iowa",Todd Warner,M,0,00:38:11.00,?,https://dev.juggle.org/history/champs/champs2005.php
-07/05/2005,2005,3b 5km,Yes,St Paul's Spring Tune-up,Riley McLincha,M,USA,00:26:20.00,3,https://www.athlinks.com/event/138944/results/Event/24014/Course/36946/Bib/708
-09/01/2005,2005,3b Marathon,Yes,Rock 'n' Roll Arizona,Perry Romanowski,M,USA,03:28:01.00,?,https://marathonview.net/result/61221540
-10/10/2004,2004,3b Marathon,Yes,Chicago Marathon,Perry Romanowski,M,USA,03:25:49.00,?,https://chicago-history.r.mikatiming.com/2021/?pid=search
-26/09/2004,2004,3b Marathon,Yes,Berlin Marathon,Peter Meyer,M,DEU,04:47:47.00,2,https://marathonview.net/search?query=peter%20meyer  http://home.mnet-online.de/joggling/aboutme_d.htm
-13/07/2004,2004,3b 5km,Yes,"IJA, Buffalo",Jamie Whoolery,M,0,00:26:16.00,?,https://dev.juggle.org/history/champs/champs2004.php
-13/07/2004,2004,3b 5km,Yes,"IJA, Buffalo",Andrew Swan,M,0,00:29:15.00,?,https://dev.juggle.org/history/champs/champs2004.php
-13/07/2004,2004,3b 5km,Yes,"IJA, Buffalo",Dorothy Finnigan,F,0,00:35:49.00,?,https://dev.juggle.org/history/champs/champs2004.php
-06/06/2004,2004,3b Marathon,Yes,San Diego Rock 'n' Roll,Perry Romanowski,M,USA,03:59:51.00,?,https://marathonview.net/result/60090344
-11/01/2004,2004,3b Marathon,Yes,Rock 'n' Roll Arizona,Perry Romanowski,M,USA,03:50:21.00,?,https://marathonview.net/result/61212976
-05/10/2003,2003,3b Marathon,Yes,"Twin Cities Marathon, Minnesota",Perry Romanowski,M,USA,03:51:38.00,?,
-31/05/2003,2003,3b 10km,Yes,Oak Apple Run,Riley McLincha,M,USA,00:47:45.00,6,https://www.athlinks.com/event/28458/results/Event/59571/Course/362940/Entry/139702147
-28/04/2003,2003,3b Marathon,Yes,Cleveland Marathon,Perry Romanowski,M,USA,04:12:56.00,?,
-27/04/2003,2003,3b Half Marathon,Yes,West Bloomfield 1/2 Marathon,Riley McLincha,M,USA,02:12:42.00,15,https://www.athlinks.com/event/38318/results/Event/12960/Course/19137/Entry/8202460
-01/02/2003,2003,3b Mile,Yes,"Atlanta, Georgia",Will Howard,M,USA,00:04:42.00,?,http://www.atlantajugglers.org/aja-media/articles-by-our-members/86-joggling-world-record
-06/10/2002,2002,3b Marathon,Yes,Milwaukee Marathon,Perry Romanowski,M,USA,04:11:48.00,?,
-17/07/2002,2002,3b 5km,Yes,"IJA, Reading, Pennsylvania",Mike Hebebrand,M,USA,00:19:52.00,?,https://dev.juggle.org/history/champs/champs2002.php
-17/07/2002,2002,3b 5km,Yes,"IJA, Reading, Pennsylvania",Andrew Swan,M,0,00:24:26.00,?,https://dev.juggle.org/history/champs/champs2002.php
-17/07/2002,2002,3b 5km,Yes,"IJA, Reading, Pennsylvania",Jake Immerman,M,0,00:25:36.00,?,https://dev.juggle.org/history/champs/champs2002.php
-17/07/2002,2002,3b 5km,Yes,"IJA, Reading, Pennsylvania",Heather Marriott,F,USA,00:25:43.00,?,https://dev.juggle.org/history/champs/champs2002.php
-17/07/2002,2002,3b 5km,Yes,"IJA, Reading, Pennsylvania",Timmy Boas,M,0,00:25:57.00,?,https://dev.juggle.org/history/champs/champs2002.php
-17/07/2002,2002,3b 5km,Yes,"IJA, Reading, Pennsylvania",Danny Tomaro,M,0,00:27:35.00,?,https://dev.juggle.org/history/champs/champs2002.php
-17/07/2002,2002,3b 5km,Yes,"IJA, Reading, Pennsylvania",Gil Pontius,M,0,00:28:44.00,?,https://dev.juggle.org/history/champs/champs2002.php
-06/05/2002,2002,3b Marathon,Yes,"Flying Pig Marathon, Cincinnati",Perry Romanowski,M,USA,04:25:25.00,?,https://marathonview.net/result/60881124
-07/10/2001,2001,3b Marathon,Yes,Chicago Marathon,Perry Romanowski,M,USA,04:25:25.00,?,https://chicago-history.r.mikatiming.com/2021/?pid=search
-28/07/2001,2001,3b Mile,Yes,"IJA, Wisconsin",Jamie Whoolery,M,0,00:05:53.00,?,https://dev.juggle.org/history/champs/champs2001.php
-28/07/2001,2001,3b Mile,Yes,"IJA, Wisconsin",Mike Draney,M,0,00:06:06.00,?,https://dev.juggle.org/history/champs/champs2001.php
-28/07/2001,2001,3b Mile,Yes,"IJA, Wisconsin",Andrew Swan,M,0,00:06:27.00,?,https://dev.juggle.org/history/champs/champs2001.php
-28/07/2001,2001,3b Mile,Yes,"IJA, Wisconsin",Heather Marriott,F,USA,00:07:15.00,?,https://dev.juggle.org/history/champs/champs2001.php
-28/07/2001,2001,3b Mile,Yes,"IJA, Wisconsin",Steve Caruso,M,0,00:07:25.00,?,https://dev.juggle.org/history/champs/champs2001.php
-28/07/2001,2001,3b Mile,Yes,"IJA, Wisconsin",Vytas Vaitkus,M,0,00:07:25.00,?,https://dev.juggle.org/history/champs/champs2001.php
-28/07/2001,2001,3b Mile,Yes,"IJA, Wisconsin",Glenn Ritter,M,0,00:07:50.00,?,https://dev.juggle.org/history/champs/champs2001.php
-28/07/2001,2001,3b Mile,Yes,"IJA, Wisconsin",Charles Schweitzer,M,USA,00:08:18.00,?,https://dev.juggle.org/history/champs/champs2001.php
-28/04/2001,2001,3b Marathon,Yes,Nashville Country Music Marathon,Perry Romanowski,M,USA,04:18:28.00,?,
-22/04/2001,2001,3c Marathon,No,London Marathon,Colin Francome,M,GBR,06:03:22.00,?,https://www.gazetteandherald.co.uk/news/7366767.serious-stuff-for-colin-the-clown/  https://marathonview.net/search?query=colin%20francome
-22/10/2000,2000,3b Marathon,Yes,Chicago Marathon,Perry Romanowski,M,USA,04:16:06.00,?,https://chicago-history.r.mikatiming.com/2021/?pid=search
-10/08/2000,2000,3b Marathon,Yes,"Karlsruhe, Germany",Paul-Erik Lillholm,M,NOR,03:20:49.00,?,
-05/08/2000,2000,3b Mile,Yes,"IJA, Montreal",Jamie Whoolery,M,0,00:05:58.00,?,https://dev.juggle.org/history/champs/champs2000.php
-05/08/2000,2000,3b Mile,Yes,"IJA, Montreal",Sam Hartford,M,0,00:06:02.00,?,https://dev.juggle.org/history/champs/champs2000.php
-05/08/2000,2000,3b Mile,Yes,"IJA, Montreal",Gil Pontius,M,0,00:06:35.00,?,https://dev.juggle.org/history/champs/champs2000.php
-05/08/2000,2000,3b Mile,Yes,"IJA, Montreal",Joshua Edleman,M,0,00:06:39.00,?,https://dev.juggle.org/history/champs/champs2000.php
-05/08/2000,2000,3b Mile,Yes,"IJA, Montreal",Lana Bolin,F,0,00:06:49.00,?,https://dev.juggle.org/history/champs/champs2000.php
-05/08/2000,2000,3b Mile,Yes,"IJA, Montreal",Andrew Swan,M,0,00:06:58.00,?,https://dev.juggle.org/history/champs/champs2000.php
-05/08/2000,2000,3b Mile,Yes,"IJA, Montreal",Simon George,M,0,00:07:00.00,?,https://dev.juggle.org/history/champs/champs2000.php
-05/08/2000,2000,3b Mile,Yes,"IJA, Montreal",Tim Baird,M,0,00:07:15.00,?,https://dev.juggle.org/history/champs/champs2000.php
-05/08/2000,2000,3b 5km,Yes,"IJA, Montreal",Andrew Swan,M,0,00:23:45.00,?,https://dev.juggle.org/history/champs/champs2000.php
-05/08/2000,2000,3b 5km,Yes,"IJA, Montreal",Sam Hartford,M,0,00:23:46.00,?,https://dev.juggle.org/history/champs/champs2000.php
-05/08/2000,2000,3b 5km,Yes,"IJA, Montreal",Joshua Edleman,M,0,00:24:35.00,?,https://dev.juggle.org/history/champs/champs2000.php
-24/10/1999,1999,3b Marathon,Yes,Chicago Marathon,Perry Romanowski,M,USA,04:07:18.00,?,https://chicago-history.r.mikatiming.com/2021/?pid=search
-19/10/1997,1997,3b Marathon,Yes,Chicago Marathon,Perry Romanowski,M,USA,04:09:49.00,?,https://chicago-history.r.mikatiming.com/2021/?pid=search
-19/10/1997,1997,3b Marathon,Yes,Detroit Free Press Marathon,Riley McLincha,M,USA,05:21:12.00,30,https://www.athlinks.com/event/154412/results/Event/15106/Course/22290/Entry/10440441
-20/10/1996,1996,3b Marathon,Yes,Chicago Marathon,Perry Romanowski,M,USA,04:05:41.00,?,https://chicago-history.r.mikatiming.com/2021/?pid=search
-05/12/1991,1991,3b Marathon,Yes,California International Marathon,Bill Coad,M,USA,04:43:38.00,?,https://www.justyouraveragejoggler.com/bill-coad-entertainer-business-owner-and-joggler/  https://marathonview.net/search?query=william%20coad
-05/03/1989,1989,3b Marathon,Yes,Los Angeles Marathon,Mike Hebebrand,M,USA,03:32:00.00,10,https://www.latimes.com/archives/la-xpm-1989-04-24-me-1750-story.html
-06/11/1988,1988,5b Marathon,Yes,New York City Marathon,Billy Gillen,M,USA,07:07:16.00,?,"https://results.nyrr.org/event/881106/finishers/1329691#search=William%2520Gillen     https://www.dev.juggle.org/history/archives/jugmags/41-3/41-3,p6.htm"
-04/07/1988,1988,3b Marathon,Yes,Salmon River Idaho,Ashrita Furman,M,USA,03:22:32.00,?,
-01/11/1987,1987,3b Marathon,Yes,New York Marathon,Albert Lucas,M,USA,03:58:43.00,?,His second joggling marathon. http://www.juggling.org/jw/87/4/notes.html
-01/03/1987,1987,3b Marathon,Yes,Los Angeles Marathon,Albert Lucas,M,USA,04:04:35.00,0,Albert's first joggling marathon. https://www.instagram.com/p/B9awUjCHeG-/ Also documented in Jugglers World Spring 1987 Newsletter
-30/05/1982,1982,3b Marathon,Yes,Montreal International Marathon,Michel Lauzière,M,CAN,03:57:00.00,?,Email exchange
-12/09/1981,1981,3b Marathon,Yes,Montreal International Marathon,Michel Lauzière,M,CAN,04:05:00.00,1,"The very first marathon joggled http://www.dev.juggle.org/history/archives/jugmags/33-5/33-5,p28.htm  https://michellauziere.com/en/biography?fbclid=IwAR2anhLNF-oEFjURGW7YdlZSqmlNxilYRQdh3MeirIdGkLK9dzQRfV8nOwM"
-16/07/1981,1981,3b 1500m,Yes,"IJA, Cleveland, Ohio",Michel Lauzière,M,CAN,00:05:03.00,?,"Email exchange inc photo of newpaper article, http://www.juggling.org/orgs/ija/champs.txt"
-16/07/1981,1981,3b 1500m,Yes,"IJA, Cleveland, Ohio",Bill Giduz,M,USA,00:05:26.00,?,https://dev.juggle.org/history/champs/champs1981.php
-16/07/1981,1981,3b 1500m,Yes,"IJA, Cleveland, Ohio",Gerry Berg,M,0,00:05:36.00,?,https://dev.juggle.org/history/champs/champs1981.php
-16/07/1981,1981,3b 5km,Yes,"IJA, Cleveland, Ohio",Paul Williams,M,0,00:20:11.00,?,https://dev.juggle.org/history/champs/champs1981.php
-16/07/1981,1981,3b 5km,Yes,"IJA, Cleveland, Ohio",Larry Kluger,M,0,00:21:09.00,?,https://dev.juggle.org/history/champs/champs1981.php
-16/07/1981,1981,3b 5km,Yes,"IJA, Cleveland, Ohio",Dan Berg,M,0,00:21:34.00,?,https://dev.juggle.org/history/champs/champs1981.php
+11/01/2015,2015,5b Marathon,Yes,"Disney Marathon, Orlando, FL",Barry Goldmeier,M,USA,09:31.0,?,http://www.marathonguide.com/results/browse.cfm?MIDD=481150111&Gen=B&Begin=13321&End=13420&Max=19959
+16/11/2014,2014,3b Marathon,Yes,Istanbul Marathon,Levent Denizci,M,TUR,28:48.0,11,https://www.instagram.com/p/B8fnCXJAdqf/?hl=en  https://marathonview.net/search?query=levent%20denizci  https://www.instagram.com/p/BI34IF9jS2e/
+02/11/2014,2014,3b Marathon,Yes,New York City Marathon,Jack Hirschowitz,M,USA,41:49.0,?,https://results.nyrr.org/event/M2014/finishers#search=Jack%2520Hirschowitz
+19/10/2014,2014,3b Half Marathon,Yes,Toronto Waterfront Half Marathon,Michal Kapral,M,CAN,20:40.0,?,
+12/10/2014,2014,3b Marathon,Yes,Chicago Marathon,Perry Romanowski,M,USA,40:45.0,?,https://chicago-history.r.mikatiming.com/2021/?pid=search
+28/09/2014,2014,3b Marathon,Yes,"Yonkers Marathon, New York",Chris Pert,M,USA,40:40.0,0,https://marathonview.net/search?query=christopher%20pert
+21/06/2014,2014,3b 5km,Yes,"Bangor Parkrun, Northern Ireland",Nathan Agnew,M,GBR,27:43.0,?,https://www.parkrun.org.uk/bangor/results/13/ https://www.parkrun.org.uk/bangor/news/2014/06/24/parkrun-achieves-over-2600-runners-200-volunteers/
+21/06/2014,2014,3b Half Marathon,Yes,Garry Bjorklund Half Marathon,Ivan Schleppenbach,M,USA,36:15.0,?,https://www.mtecresults.com/runner/show?race=2165&rid=11928
+08/06/2014,2014,3b 5km,Yes,"Rocky Neck 5k, Gloucester, MA",Richard Ross,M,USA,20:27.0,?,https://goodmorninggloucester.files.wordpress.com/2014/06/image25.png     https://youtu.be/GoE4pZ39SAY
+10/05/2014,2014,3b Half Marathon,Yes,Fargo Half Marathon,Ivan Schleppenbach,M,USA,38:58.0,?,https://www.mtecresults.com/runner/show?race=2183&rid=8438
+06/04/2014,2014,3b 5km,Yes,"CoDependency 5k, Cooper River Park",Dana Giuglielmo,F,USA,20:40.0,3,https://tomahawktiming.com/road-races/2014-season/46-codependency-5k-cooper-river/  https://medium.com/the-moorestown-sun/dana-guglielmo-breaks-guinness-world-record-for-joggling-8f1a107d5774
+06/04/2014,2014,3b Marathon,Yes,Brighton Marathon,Kevin Williams,M,GBR,38:18.0,?,https://www.theargus.co.uk/news/11010177.brighton-man-to-run-half-marathon-while-juggling-after-recovering-from-brain-injury/?fbclid=IwAR1USEy4inlcpMOKmdBCvst5ie4hlTLXAmXm0OyXbXI8X3sHv9V34gs7V68  https://marathonview.net/search?query=kevin%20williams
+28/02/2014,2014,3b Marathon,Yes,Tel Aviv Marathon,Shahar Cohen,M,ISR,25:17.0,?,https://marathonview.net/search?query=Shahar%20Cohen  https://www.israel21c.org/israeli-juggler-sets-new-record-at-the-sea-of-galilee/
+17/11/2013,2013,3b Marathon,Yes,Brooklyn Marathon,Chris Pert,M,USA,52:33.0,2,https://marathonview.net/search?query=christopher%20pert
+03/11/2013,2013,3b Marathon,Yes,New York City Marathon,Jack Hirschowitz,M,USA,42:07.0,?,https://results.nyrr.org/event/40/finishers#search=Jack%2520Hirschowitz
+13/10/2013,2013,3b Marathon,Yes,Chicago Marathon,Perry Romanowski,M,USA,42:23.0,?,https://chicago-history.r.mikatiming.com/2021/?pid=search
+29/09/2013,2013,3b Marathon,Yes,"Yonkers Marathon, New York",Chris Pert,M,USA,51:43.0,4,https://acrotrekker.wordpress.com/tag/christopher-pert-joggler/
+22/09/2013,2013,3b Marathon,Yes,Quad Cities Marathon,Joe Salter,M,USA,51:25.0,?,Backwards. https://www.guinnessworldrecords.com/world-records/100547-fastest-marathon-joggling-backwards
+22/06/2013,2013,3b Half Marathon,Yes,Garry Bjorklund Half Marathon,Ivan Schleppenbach,M,USA,41:10.0,?,https://www.mtecresults.com/runner/show?race=1394&rid=13151
+18/05/2013,2013,3b Half Marathon,Yes,Fargo Half Marathon,Ivan Schleppenbach,M,USA,47:04.0,?,https://www.mtecresults.com/runner/show?race=1386&rid=6886
+15/05/2013,2013,3b Mile,Yes,Time Trial,Emily Beaver,F,USA,05:58.0,?,https://missouristatebears.com/news/2013/5/15/Emily_Beaver_Sets_World_Record_for_Joggling https://www.guinnessworldrecords.com/world-records/fastest-mile-joggling-with-three-objects-women
+05/05/2013,2013,3b Marathon,Yes,"Flying Pig Marathon, Cincinnati",Perry Romanowski,M,USA,46:34.0,?,https://marathonview.net/result/42981151
+07/04/2013,2013,3b Marathon,Yes,Paris Marathon,Richard Ross,M,USA,00:43.0,?,https://marathonview.net/result/66848234
+07/10/2012,2012,3b Marathon,Yes,"Trapline Marathon, Labrador, Newfoundland",Michal Kapral,M,CAN,59:32.0,?,https://www.nlaa.ca/results/rr/2012/20121007traplinemarathon.php
+07/10/2012,2012,3b Marathon,Yes,Chicago Marathon,Perry Romanowski,M,USA,40:50.0,?,https://chicago-history.r.mikatiming.com/2021/?pid=search
+13/08/2012,2012,3b Mile,Yes,"Pride Stadium, Clio MI",Riley McLincha,M,USA,08:44.0,0,https://recordsetter.com/world-record/run-mile-while-dribbling-three-basketballs/17315?autoplay=false
+27/07/2012,2012,5b Mile,Yes,Time Trial,Matthew Feldman,M,USA,06:33.0,?,
+23/06/2012,2012,3b 5km,Yes,"Fishers Freedom 5km, Indiana",Bob Evans,M,USA,16:34.0,?,https://www.onlineraceresults.com/race/view_race.php?race_id=25925&num=15&split=TIME&submit_action=Refresh+Leaders#racetop
+23/06/2012,2012,3b 5km,Yes,"Fishers Freedom 5km, Indiana",Trish Evans,F,USA,20:10.0,?,https://www.onlineraceresults.com/race/view_race.php?race_id=25925&num=15&split=TIME&submit_action=Refresh+Leaders#racetop
+16/04/2012,2012,3b Marathon,Yes,Boston Marathon,Tom Gounley,M,USA,52:33.0,?,http://registration.baa.org/2012/cf/public/iframe_ResultsSearch.cfm?mode=results  https://www.youtube.com/watch?v=LYoont-ebxA
+04/03/2012,2012,3b 5km,Yes,"Super Kids Sunday 5k, Long Beach, California",Bob Evans,M,USA,16:42.0,?,https://thejoggler.blogspot.com/2012/03/bob-evans-lowers-5k-joggling-record-to.html
+18/02/2012,2012,3b 5km,Yes,Highbury Fields Parkrun,Ralph Kidner,M,GBR,25:37.0,?,https://www.parkrun.org.uk/highburyfields/results/15/
+16/11/2011,2011,3b Half Marathon,Yes,"Des Moines Half Marathon, Iowa",Tyler Wishau,M,USA,25:45.0,?,https://www.onlineraceresults.com/race/view_race.php?race_id=21745&re_NO=e.g.%2C+1946&re_FN=e.g.%2C+Joe&re_LN=Wishau&re_CITY=&re_STATE=&re_DIVISION=&submit_action=select_result&race_id=21745#results      https://www.dmu.edu/blog/2012/03/joggler-juggles-more-than-medical-school/
+12/11/2011,2011,3b 10km,Yes,"Mandarin Run, Jacksonville, Florida",Bob Evans,M,USA,35:41.0,?,http://1stplacesports.com/man11gradedres.htm
+12/11/2011,2011,3b 10km,Yes,"Mandarin Run, Jacksonville, Florida",Trish Evans,F,USA,42:58.0,?,http://www.recordholders.org/en/list/joggling.html
+12/11/2011,2011,3b Marathon,Yes,SunTrust Richmond (Virginia) Marathon,Jesse Joyner,M,USA,48:17.0,4,https://www.trackshackresults.com/richmond/results/2011/mar_results.php?Link=5&Type=3&LName=Joyner&FName=Jesse&City=&State=&Country=
+06/11/2011,2011,3b Marathon,Yes,New York City Marathon,Jack Hirschowitz,M,USA,43:53.0,?,http://www.marathonguide.com/results/search.cfm
+29/10/2011,2011,3b 5km,Yes,"Race for the Cure in Nashville, Tennessee",Bob Evans,M,USA,16:51.0,?,https://www.prweb.com/releases/catchitearly/joggling-world-record/prweb8929941.htm
+09/10/2011,2011,3b Marathon,Yes,Chicago Marathon,Perry Romanowski,M,USA,35:58.0,?,https://chicago-history.r.mikatiming.com/2021/?pid=search
+28/08/2011,2011,3b Ulta (57m),No,Boston 12 Hour Race,Tim Butler,M,GBR,00:00.0,?,https://www.joggling.co.uk/Marathon-List
+20/07/2011,2011,3b 5km,Yes,"IJA, Rochester",Charles Schweitzer,M,USA,17:57.0,?,https://dev.juggle.org/history/champs/champs2011.php
+20/07/2011,2011,3b 5km,Yes,"IJA, Rochester",Tyler Wishau,M,USA,18:38.0,?,https://dev.juggle.org/history/champs/champs2011.php
+20/07/2011,2011,3b 5km,Yes,"IJA, Rochester",Bob Evans,M,USA,19:01.0,?,https://dev.juggle.org/history/champs/champs2011.php
+20/07/2011,2011,3b 5km,Yes,"IJA, Rochester",Billy Watson,M,0,20:00.0,?,https://dev.juggle.org/history/champs/champs2011.php
+20/07/2011,2011,3b 5km,Yes,"IJA, Rochester",Chris Merra,M,0,21:41.0,?,https://dev.juggle.org/history/champs/champs2011.php
+20/07/2011,2011,3b 5km,Yes,"IJA, Rochester",Trish Evans,F,USA,21:46.0,?,https://dev.juggle.org/history/champs/champs2011.php
+20/07/2011,2011,3b 5km,Yes,"IJA, Rochester",John Kilgust,M,0,27:18.0,?,https://dev.juggle.org/history/champs/champs2011.php
+20/07/2011,2011,3b 5km,Yes,"IJA, Rochester",Dean Bennett,M,0,28:54.0,?,https://dev.juggle.org/history/champs/champs2011.php
+20/07/2011,2011,3b 5km,Yes,"IJA, Rochester",Nathan Wakefield,M,0,29:28.0,?,https://dev.juggle.org/history/champs/champs2011.php
+24/05/2011,2011,5b 5km,Yes,Time Trial,Matthew Feldman,M,USA,27:06.0,?,
+22/05/2011,2011,3b Half Marathon,Yes,Edinburgh Half Marathon,Steve Portwine,M,GBR,04:03.0,6,https://www.podiumrunner.com/events/the-tale-of-the-scottish-joggler/  https://www.getreading.co.uk/news/local-news/woodley-man-steve-portwine-juggle-4214204
+22/05/2011,2011,3b Marathon,Yes,Edinburgh Marathon,Ralph Kidner,M,GBR,37:31.0,48,https://www.edinburghmarathon.com/results?name=ralph+kidner&running_number=&event=28&gender=&age_category=
+24/04/2011,2011,3b Marathon,Yes,London Marathon,Tim Butler,M,GBR,06:20.0,?,https://www.joggling.co.uk/Marathon-List
+17/04/2011,2011,3c Marathon,No,London Marathon,Colin Francome,M,GBR,32:23.0,?,https://www.justgiving.com/fundraising/colinfrancome https://marathonview.net/search?query=colin%20francome
+10/04/2011,2011,3b Marathon,Yes,Paris Marathon,Perry Romanowski,M,USA,58:05.0,?,https://marathonview.net/result/43416935
+29/01/2011,2011,3b 50 Mile,Yes,Yorkshire Frostbite 50,Tim Butler,M,GBR,34:00.0,?,https://www.joggling.co.uk/Marathon-List
+07/11/2010,2010,3b Marathon,Yes,Rutland Water Marathon,Tim Butler,M,GBR,34:19.0,?,https://www.joggling.co.uk/Marathon-List
+10/10/2010,2010,4b Half Marathon,No,Munich Half Marathon,Peter Meyer,M,DEU,21:07.0,15,99% 4 balls - this is close enough! https://muenchen.r.mikatiming.de/2010/?pid=search  http://home.mnet-online.de/joggling/aboutme_d.htm
+10/10/2010,2010,3b Marathon,Yes,Chicago Marathon,Perry Romanowski,M,USA,38:08.0,?,https://chicago-history.r.mikatiming.com/2021/?pid=search
+10/10/2010,2010,5b Marathon,Yes,Chicago Marathon,Barry Goldmeier,M,USA,51:41.0,?,http://www.marathonguide.com/results/browse.cfm?MIDD=67101010&Gen=B&Begin=31706&End=31805&Max=36159
+08/08/2010,2010,3c Half Marathon,Yes,Newark Half Marathon,Tim Butler,M,GBR,24:00.0,?,https://www.youtube.com/watch?v=K0y6jjFVx7o  https://www.facebook.com/photo/?fbid=1467928150956&set=a.1200853594259
+23/07/2010,2010,3b Ulta (70m),No,Grimsthorpe Ultramarathon,Tim Butler,M,GBR,28:00.0,?,https://www.joggling.co.uk/Marathon-List
+24/04/2010,2010,3b Marathon,Yes,Nashville Country Music Marathon,Perry Romanowski,M,USA,48:25.0,?,
+06/12/2009,2009,3b Marathon,Yes,Rock 'n' Roll Las Vegas,Perry Romanowski,M,USA,08:48.0,?,
+22/11/2009,2009,3b Marathon,Yes,Philadelphia Marathon,Perry Romanowski,M,USA,27:29.0,?,https://marathonview.net/result/60673065
+22/11/2009,2009,3b Marathon,Yes,Philadelphia Marathon,Joe Salter,M,USA,31:11.0,?,
+22/11/2009,2009,3b Marathon,Yes,Philadelphia Marathon,Barry Goldmeier,M,USA,53:46.0,?,https://marathonview.net/search?query=Barry%20Goldmeier  https://www.facebook.com/photo/?fbid=1770227386337053&set=gm.717510868420766
+18/10/2009,2009,3b Marathon,Yes,Spires and Steeples,Tim Butler,M,GBR,35:16.0,?,https://www.joggling.co.uk/Marathon-List
+11/10/2009,2009,3b Marathon,Yes,Munich Marathon,Peter Meyer,M,DEU,28:54.0,12,80% with 4 balls. https://marathonview.net/search?query=peter%20meyer  http://home.mnet-online.de/joggling/aboutme_d.htm
+26/09/2009,2009,3b Marathon,Yes,Akron Marathon,David Livingston,M,USA,28:56.0,?,https://eu.beaconjournal.com/story/news/local/2015/09/24/wooster-runner-hopes-to-set/10301568007/  https://marathonview.net/search?query=david%20livingston
+14/07/2009,2009,3b 100m,Yes,"IJA, Winston-Salem",David Ferman,M,USA,00:13.9,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 100m,Yes,"IJA, Winston-Salem",Tyler Wishau,M,USA,00:14.5,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 100m,Yes,"IJA, Winston-Salem",Jeremy Stanley,M,0,00:14.7,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 100m,Yes,"IJA, Winston-Salem",Chris Lovdal,M,0,00:14.8,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 100m,Yes,"IJA, Winston-Salem",Ben Fry,M,0,00:15.2,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 100m,Yes,"IJA, Winston-Salem",Anders Kierulf,M,0,00:15.4,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 100m,Yes,"IJA, Winston-Salem",Chuck Hawley,M,0,00:15.7,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 100m,Yes,"IJA, Winston-Salem",Matt Gifford,M,0,00:16.0,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 100m,Yes,"IJA, Winston-Salem",Daniel Rose,M,0,00:16.1,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 100m,Yes,"IJA, Winston-Salem",Peter Blanchard,M,0,00:16.1,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 100m,Yes,"IJA, Winston-Salem",Amanda Richter,F,0,00:16.1,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 100m,Yes,"IJA, Winston-Salem",Jack Levy,M,0,00:16.2,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 100m,Yes,"IJA, Winston-Salem",Austin Bruckner,M,0,00:16.6,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 100m,Yes,"IJA, Winston-Salem",Andrew Hodge,M,0,00:17.3,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 100m,Yes,"IJA, Winston-Salem",Andrew Swan,M,0,00:17.5,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 100m,Yes,"IJA, Winston-Salem",Andrew Ruiz,M,0,00:17.7,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 100m,Yes,"IJA, Winston-Salem",Colin Revere,M,0,00:17.7,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 100m,Yes,"IJA, Winston-Salem",Neil Jordan,M,0,00:18.0,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 100m,Yes,"IJA, Winston-Salem",Tom McClintock,M,0,00:18.0,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 100m,Yes,"IJA, Winston-Salem",Rory Bade,M,0,00:18.4,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 100m,Yes,"IJA, Winston-Salem",Taylor Glenn,F,0,00:18.8,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 100m,Yes,"IJA, Winston-Salem",Hannah Staehr,F,0,00:18.8,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 100m,Yes,"IJA, Winston-Salem",Heather Marriott,F,USA,00:19.0,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 100m,Yes,"IJA, Winston-Salem",Daniel Eaker,M,0,00:19.3,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 100m,Yes,"IJA, Winston-Salem",Laura Ernst,F,0,00:19.5,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 100m,Yes,"IJA, Winston-Salem",Joey Spicola,M,0,00:19.7,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 100m,Yes,"IJA, Winston-Salem",Paul Arneberg,M,0,00:19.9,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 100m,Yes,"IJA, Winston-Salem",Jack Hirschowitz,M,USA,00:20.1,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 100m,Yes,"IJA, Winston-Salem",Kelsey Harr,F,0,00:21.6,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 100m,Yes,"IJA, Winston-Salem",Kyler McClintock,M,0,00:22.6,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,5b 100m,Yes,"IJA, Winston-Salem",David Ferman,M,USA,00:22.6,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 100m,Yes,"IJA, Winston-Salem",Sofia Meyer,F,0,00:24.6,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 100m,Yes,"IJA, Winston-Salem",Jean Guy Beaudry,M,0,00:25.0,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 100m,Yes,"IJA, Winston-Salem",Quentin Dombro,M,0,00:27.6,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 200m,Yes,"IJA, Winston-Salem",David Ferman,M,USA,00:28.0,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 100m,Yes,"IJA, Winston-Salem",Chloe Hirschowitz,F,USA,00:28.1,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 100m,Yes,"IJA, Winston-Salem",Silas Wallen-Friedman,M,0,00:28.8,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 100m,Yes,"IJA, Winston-Salem",Stephanie Walsh,F,0,00:29.1,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 200m,Yes,"IJA, Winston-Salem",Chris Lovdal,M,0,00:29.9,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 200m,Yes,"IJA, Winston-Salem",Tyler Wishau,M,USA,00:30.8,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 100m,Yes,"IJA, Winston-Salem",Lee Gifford,M,0,00:31.0,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 200m,Yes,"IJA, Winston-Salem",Ben Fry,M,0,00:31.6,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 200m,Yes,"IJA, Winston-Salem",Jeremy Stanley,M,0,00:32.4,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 200m,Yes,"IJA, Winston-Salem",Len Ferman,M,USA,00:33.2,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 200m,Yes,"IJA, Winston-Salem",Anders Kierulf,M,0,00:33.5,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 100m,Yes,"IJA, Winston-Salem",Markus Furtner,M,0,00:34.0,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,5b 100m,Yes,"IJA, Winston-Salem",Andrew Ruiz,M,0,00:34.0,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,5b 100m,Yes,"IJA, Winston-Salem",Daniel Eaker,M,0,00:34.1,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 100m,Yes,"IJA, Winston-Salem",Kurt Siefken,M,0,00:34.1,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,5b 100m,Yes,"IJA, Winston-Salem",Kyler McClintock,M,0,00:34.8,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,5b 100m,Yes,"IJA, Winston-Salem",Austin Bruckner,M,0,00:34.8,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 200m,Yes,"IJA, Winston-Salem",Kyler McClintock,M,0,00:35.4,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 100m,Yes,"IJA, Winston-Salem",Evan Peter,M,0,00:35.7,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 200m,Yes,"IJA, Winston-Salem",Peter Blanchard,M,0,00:36.5,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 200m,Yes,"IJA, Winston-Salem",Neil Jordan,M,0,00:36.6,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 200m,Yes,"IJA, Winston-Salem",Jean Guy Beaudry,M,0,00:36.6,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,5b 100m,Yes,"IJA, Winston-Salem",Jeremy Stanley,M,0,00:38.3,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 200m,Yes,"IJA, Winston-Salem",Austin Bruckner,M,0,00:38.3,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 200m,Yes,"IJA, Winston-Salem",Rory Bade,M,0,00:38.3,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 200m,Yes,"IJA, Winston-Salem",Colin Revere,M,0,00:39.3,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,5b 100m,Yes,"IJA, Winston-Salem",Jack Levy,M,0,00:39.6,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 200m,Yes,"IJA, Winston-Salem",Paul Arneberg,M,0,00:41.1,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 200m,Yes,"IJA, Winston-Salem",Daniel Rose,M,0,00:41.3,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 200m,Yes,"IJA, Winston-Salem",Amanda Richter,F,0,00:41.5,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 200m,Yes,"IJA, Winston-Salem",Jack Levy,M,0,00:41.6,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 200m,Yes,"IJA, Winston-Salem",Andrew Hodge,M,0,00:42.9,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,5b 100m,Yes,"IJA, Winston-Salem",Andrew Hodge,M,0,00:43.3,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 200m,Yes,"IJA, Winston-Salem",Sofia Meyer,F,0,00:44.8,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 200m,Yes,"IJA, Winston-Salem",Evan Peter,M,0,00:48.5,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,5b 100m,Yes,"IJA, Winston-Salem",Silas Wallen-Friedman,M,0,00:50.0,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 200m,Yes,"IJA, Winston-Salem",Hannah Staehr,F,0,00:50.2,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 200m,Yes,"IJA, Winston-Salem",Chloe Hirschowitz,F,USA,00:52.2,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 200m,Yes,"IJA, Winston-Salem",Laura Ernst,F,0,00:52.2,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 200m,Yes,"IJA, Winston-Salem",Markus Furtner,M,0,00:52.4,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,5b 100m,Yes,"IJA, Winston-Salem",Chuck Hawley,M,0,00:54.4,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 200m,Yes,"IJA, Winston-Salem",Andrew Swan,M,0,01:00.4,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,5b 100m,Yes,"IJA, Winston-Salem",Joey Spicola,M,0,01:02.8,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 4x100m,Yes,"IJA, Winston-Salem","Len Ferman, David Ferman, Tyler Wishau, Ben Fry",M,#N/A,01:03.0,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 400m,Yes,"IJA, Winston-Salem",David Ferman,M,USA,01:03.3,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,5b 100m,Yes,"IJA, Winston-Salem",Andrew Swan,M,0,01:04.0,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 400m,Yes,"IJA, Winston-Salem",Tyler Wishau,M,USA,01:04.5,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,5b 100m,Yes,"IJA, Winston-Salem",Rory Bade,M,0,01:05.2,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,7b 100m,Yes,"IJA, Winston-Salem",David Ferman,M,USA,01:06.0,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,5b 100m,Yes,"IJA, Winston-Salem",Taylor Glenn,F,0,01:07.5,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,5b 100m,Yes,"IJA, Winston-Salem",Amanda Richter,F,0,01:09.0,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,5b 100m,Yes,"IJA, Winston-Salem",Len Ferman,M,USA,01:09.1,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 4x100m,Yes,"IJA, Winston-Salem","Rory Bade, Joey Spicola, Chris Lovdal, Silas Wallen-Friedman",M,#N/A,01:09.2,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 4x100m,Yes,"IJA, Winston-Salem","Matt Gifford, Austin Bruckner, Jeremy Stanley, Kyler McClintock",M,#N/A,01:09.4,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 400m,Yes,"IJA, Winston-Salem",Ben Fry,M,0,01:10.7,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 400m,Yes,"IJA, Winston-Salem",Chris Lovdal,M,0,01:11.0,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 4x100m,Yes,"IJA, Winston-Salem","Andrew Swan, Jean Guy Beaudry, Anders Kierulf, Jack Hirschowitz",M,#N/A,01:12.3,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,7b 100m,Yes,"IJA, Winston-Salem",Austin Bruckner,M,0,01:13.0,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 4x100m,Yes,"IJA, Winston-Salem","Amanda Richter, Jack Levy, Colin Revere, Ricky Harr",M,#N/A,01:13.9,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 4x100m,Yes,"IJA, Winston-Salem","Tom McClintock, Neil Jordan, Lee Gifford, Paul Arneberg",M,#N/A,01:14.7,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 400m,Yes,"IJA, Winston-Salem",Paul Arneberg,M,0,01:14.8,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 4x100m,Yes,"IJA, Winston-Salem","Daniel Rose, Sofia Meyer, Evan Peter, Hannah Staehr",,#N/A,01:15.8,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 400m,Yes,"IJA, Winston-Salem",Jack Levy,M,0,01:18.6,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,7b 100m,Yes,"IJA, Winston-Salem",Andrew Ruiz,M,0,01:20.0,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 400m,Yes,"IJA, Winston-Salem",Anders Kierulf,M,0,01:20.2,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,7b 100m,Yes,"IJA, Winston-Salem",Daniel Eaker,M,0,01:21.0,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 400m,Yes,"IJA, Winston-Salem",Chuck Hawley,M,0,01:21.5,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,5b 100m,Yes,"IJA, Winston-Salem",Tyler Wishau,M,USA,01:23.7,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,5b 100m,Yes,"IJA, Winston-Salem",Daniel Rose,M,0,01:23.8,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 4x100m,Yes,"IJA, Winston-Salem","Heather Marriott, Taylor Glenn, Stephanie Walsh, Laura Ernst",F,#N/A,01:25.1,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 400m,Yes,"IJA, Winston-Salem",Kyler McClintock,M,0,01:25.1,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 400m,Yes,"IJA, Winston-Salem",Andrew Hodge,M,0,01:25.3,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 400m,Yes,"IJA, Winston-Salem",Jean Guy Beaudry,M,0,01:25.6,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 400m,Yes,"IJA, Winston-Salem",Jeremy Stanley,M,0,01:25.6,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,5b 100m,Yes,"IJA, Winston-Salem",Evan Peter,M,0,01:26.4,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 4x100m,Yes,"IJA, Winston-Salem","Peter Blanchard, Andrew Hodge, Chloe Hirschowitz, Markus Furtner",M,#N/A,01:28.0,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 400m,Yes,"IJA, Winston-Salem",Heather Marriott,F,USA,01:30.6,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 400m,Yes,"IJA, Winston-Salem",Peter Blanchard,M,0,01:30.9,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 400m,Yes,"IJA, Winston-Salem",Colin Revere,M,0,01:31.1,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 400m,Yes,"IJA, Winston-Salem",Austin Bruckner,M,0,01:31.2,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 400m,Yes,"IJA, Winston-Salem",Matt Gifford,M,0,01:31.7,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 400m,Yes,"IJA, Winston-Salem",Andrew Swan,M,0,01:32.4,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 400m,Yes,"IJA, Winston-Salem",Amanda Richter,F,0,01:41.1,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 400m,Yes,"IJA, Winston-Salem",Lee Gifford,M,0,01:41.1,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 400m,Yes,"IJA, Winston-Salem",Hannah Staehr,F,0,01:42.8,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 400m,Yes,"IJA, Winston-Salem",Daniel Eaker,M,0,01:48.2,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 400m,Yes,"IJA, Winston-Salem",Stephanie Walsh,F,0,01:51.6,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,5b 100m,Yes,"IJA, Winston-Salem",Sofia Meyer,F,0,01:52.0,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,5b 100m,Yes,"IJA, Winston-Salem",Heather Marriott,F,USA,02:00.5,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 400m,Yes,"IJA, Winston-Salem",Sofia Meyer,F,0,02:01.1,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,5b 100m,Yes,"IJA, Winston-Salem",Peter Blanchard,M,0,02:01.3,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,5b 100m,Yes,"IJA, Winston-Salem",Jack Hirschowitz,M,USA,02:02.5,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,5b 100m,Yes,"IJA, Winston-Salem",Laura Ernst,F,0,02:17.4,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 800m,Yes,"IJA, Winston-Salem",Tyler Wishau,M,USA,02:21.0,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,5b 100m,Yes,"IJA, Winston-Salem",Markus Furtner,M,0,02:27.5,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 400m,Yes,"IJA, Winston-Salem",Quentin Dombro,M,0,02:30.8,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 800m,Yes,"IJA, Winston-Salem",Len Ferman,M,USA,02:32.0,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,5b 100m,Yes,"IJA, Winston-Salem",Hannah Staehr,F,0,02:39.0,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 800m,Yes,"IJA, Winston-Salem",Paul Arneberg,M,0,02:44.0,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 800m,Yes,"IJA, Winston-Salem",Ben Fry,M,0,02:52.7,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 800m,Yes,"IJA, Winston-Salem",Kyler McClintock,M,0,03:07.0,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 800m,Yes,"IJA, Winston-Salem",Neil Jordan,M,0,03:09.7,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 800m,Yes,"IJA, Winston-Salem",Anders Kierulf,M,0,03:10.2,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 800m,Yes,"IJA, Winston-Salem",Andrew Hodge,M,0,03:12.0,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 800m,Yes,"IJA, Winston-Salem",Jeremy Stanley,M,0,03:14.0,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 800m,Yes,"IJA, Winston-Salem",Peter Blanchard,M,0,03:25.0,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 800m,Yes,"IJA, Winston-Salem",Matt Gifford,M,0,03:26.6,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 800m,Yes,"IJA, Winston-Salem",Tom McClintock,M,0,03:38.0,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 800m,Yes,"IJA, Winston-Salem",Markus Furtner,M,0,03:40.0,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,7b 100m,Yes,"IJA, Winston-Salem",Jack Levy,M,0,03:41.0,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 800m,Yes,"IJA, Winston-Salem",Jean Guy Beaudry,M,0,03:45.0,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 800m,Yes,"IJA, Winston-Salem",Heather Marriott,F,USA,03:47.0,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 800m,Yes,"IJA, Winston-Salem",Andrew Ruiz,M,0,03:48.5,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 800m,Yes,"IJA, Winston-Salem",Jack Hirschowitz,M,USA,03:56.6,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 800m,Yes,"IJA, Winston-Salem",Austin Bruckner,M,0,03:58.8,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 800m,Yes,"IJA, Winston-Salem",Laura Ernst,F,0,04:19.1,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 800m,Yes,"IJA, Winston-Salem",Stephanie Walsh,F,0,04:29.1,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 800m,Yes,"IJA, Winston-Salem",Quentin Dombro,M,0,05:01.0,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 4x400m,Yes,"IJA, Winston-Salem","Markus Furtner, Tyler Wishau, Ben Fry, Tom McClintock",M,#N/A,05:18.2,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 4x400m,Yes,"IJA, Winston-Salem","Silas Wallen-Friedman, Joey Spicola, Jack Levy, Chris Lovdal",M,#N/A,05:32.3,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 1600m,No,"IJA, Winston-Salem",Tyler Wishau,M,USA,05:33.6,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 1600m,No,"IJA, Winston-Salem",Len Ferman,M,USA,05:48.7,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 4x400m,Yes,"IJA, Winston-Salem","Kyler McClintock, Jeremy Stanley, Austin Bruckner, Andrew Hodge",M,#N/A,05:49.1,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 4x400m,Yes,"IJA, Winston-Salem","Anders Kierulf, Jean Guy  Beaudry, Andrew Swan, Jack Hirschowitz",M,#N/A,06:26.5,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 4x400m,Yes,"IJA, Winston-Salem","Heather Marriott, Chloe Hirschowitz, Stephanie Walsh, Laura Ernst",F,#N/A,07:26.6,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 1600m,No,"IJA, Winston-Salem",Andrew Hodge,M,0,07:31.0,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 1600m,No,"IJA, Winston-Salem",Markus Furtner,M,0,07:37.6,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 1600m,No,"IJA, Winston-Salem",Kurt Siefken,M,0,07:40.3,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 1600m,No,"IJA, Winston-Salem",Neil Jordan,M,0,07:45.8,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 1600m,No,"IJA, Winston-Salem",Heather Marriott,F,USA,08:33.0,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 1600m,No,"IJA, Winston-Salem",Kyler McClintock,M,0,08:42.0,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 1600m,No,"IJA, Winston-Salem",Jack Hirschowitz,M,USA,08:45.0,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 1600m,No,"IJA, Winston-Salem",Tom McClintock,M,0,09:05.0,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 1600m,No,"IJA, Winston-Salem",Stephanie Walsh,F,0,10:34.0,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 5km,Yes,"IJA, Winston-Salem",Tyler Wishau,M,USA,18:47.5,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 5km,Yes,"IJA, Winston-Salem",Chuck Hawley,M,0,23:04.0,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 5km,Yes,"IJA, Winston-Salem",John Clayton,M,0,23:50.0,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 5km,Yes,"IJA, Winston-Salem",Kurt Siefken,M,0,25:52.0,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 5km,Yes,"IJA, Winston-Salem",Andrew Swan,M,0,30:52.0,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 5km,Yes,"IJA, Winston-Salem",Jack Hirschowitz,M,USA,30:55.0,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 5km,Yes,"IJA, Winston-Salem",Andrew Ruiz,M,0,32:33.0,?,https://dev.juggle.org/history/champs/champs2009.php
+14/07/2009,2009,3b 5km,Yes,"IJA, Winston-Salem",Quentin Dombro,M,0,36:30.0,?,https://dev.juggle.org/history/champs/champs2009.php
+12/07/2009,2009,3b 10km,Yes,"Graves Park, Sheffield",Ralph Kidner,M,GBR,03:30.0,6,https://www.facebook.com/photo/?fbid=1193986171276&set=a.1149082808720 & Facebook message
+12/07/2009,2009,3b 10km,Yes,"Graves Park, Sheffield",Tim Butler,M,GBR,03:30.0,2,https://www.facebook.com/photo/?fbid=1193986171276&set=a.1149082808720 & Facebook message
+21/06/2009,2009,3b 10km,Yes,Leeds 10km,Ralph Kidner,M,GBR,09:27.0,10,https://www.justgiving.com/fundraising/ralphybabe
+06/06/2009,2009,3b Marathon,Yes,"Sunburst Marathon, South Bend",Perry Romanowski,M,USA,21:38.0,?,
+19/04/2009,2009,3b Half Marathon,Yes,Montreal Half-Marathon,Michal Kapral,M,CAN,23:49.0,2,http://thejoggler.blogspot.com/2009/04/half-marathon-joggling-record.html
+11/01/2009,2009,3b Marathon,Yes,"Disney Marathon, Orlando, FL",Jeff Civillico,M,USA,24:16.0,?,https://jeffcivillico.com/joggling-disney-marathon/
+19/10/2008,2008,3b Marathon,Yes,Spires and Steeples,Tim Butler,M,GBR,39:40.0,?,https://www.joggling.co.uk/Marathon-List
+12/10/2008,2008,3b Marathon,Yes,Victoria BC Marathon,Michal Kapral,M,CAN,12:05.0,?,
+12/10/2008,2008,3b Marathon,Yes,Chicago Marathon,Perry Romanowski,M,USA,39:36.0,?,https://chicago-history.r.mikatiming.com/2021/?pid=search
+29/08/2008,2008,3b 5km,Yes,Canadian Joggle Off,Simon Hodge,M,CAN,17:04.0,5,https://thejoggler.blogspot.com/2008/08/canadian-running-magazine-5k-joggle-off.html
+29/08/2008,2008,3b 5km,Yes,Canadian Joggle Off,Michal Kapral,M,CAN,17:05.0,0,https://thejoggler.blogspot.com/2008/08/canadian-running-magazine-5k-joggle-off.html
+15/07/2008,2008,3b 100m,Yes,"IJA, Kentucky",Jeremy Stanley,M,0,00:14.1,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 100m,Yes,"IJA, Kentucky",Chris Essick,M,0,00:14.6,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 100m,Yes,"IJA, Kentucky",Anders Kierulf,M,0,00:15.0,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 100m,Yes,"IJA, Kentucky",Jason Hollandsworth,M,0,00:15.7,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 100m,Yes,"IJA, Kentucky",Tim Hark,M,0,00:15.8,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 100m,Yes,"IJA, Kentucky",Mike Monson,M,0,00:16.1,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 100m,Yes,"IJA, Kentucky",Gus Tate,M,USA,00:16.3,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 100m,Yes,"IJA, Kentucky",Andrew Swan,M,0,00:17.8,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 100m,Yes,"IJA, Kentucky",Chloe Hirschowitz,F,USA,00:19.5,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 100m,Yes,"IJA, Kentucky",Heather Marriott,F,USA,00:20.1,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 100m,Yes,"IJA, Kentucky",Austin Bruckner,M,0,00:21.4,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 100m,Yes,"IJA, Kentucky",Nathan Biggs-Penton,M,0,00:27.3,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 200m,Yes,"IJA, Kentucky",Benjamin Thompson,M,0,00:29.9,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,5b 100m,Yes,"IJA, Kentucky",Andrew Ruiz,M,0,00:31.6,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 200m,Yes,"IJA, Kentucky",Tim Hark,M,0,00:31.8,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 200m,Yes,"IJA, Kentucky",Jeremy Stanley,M,0,00:32.0,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 200m,Yes,"IJA, Kentucky",Tao Wei,M,0,00:33.1,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 200m,Yes,"IJA, Kentucky",Kyler McClintock,M,0,00:34.2,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 200m,Yes,"IJA, Kentucky",Perry Romanowski,M,USA,00:35.6,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 200m,Yes,"IJA, Kentucky",Anders Kierulf,M,0,00:36.1,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 200m,Yes,"IJA, Kentucky",Andrew Swan,M,0,00:36.5,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,5b 100m,Yes,"IJA, Kentucky",Kyler McClintock,M,0,00:37.8,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 200m,Yes,"IJA, Kentucky",Mike Monson,M,0,00:38.3,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,5b 100m,Yes,"IJA, Kentucky",Jeremy Stanley,M,0,00:38.5,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 200m,Yes,"IJA, Kentucky",Austin Bruckner,M,0,00:39.4,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 200m,Yes,"IJA, Kentucky",Heather Marriott,F,USA,00:39.4,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,5b 100m,Yes,"IJA, Kentucky",Austin Bruckner,M,0,00:39.5,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 200m,Yes,"IJA, Kentucky",Nathan Biggs-Penton,M,0,00:40.8,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,5b 100m,Yes,"IJA, Kentucky",Jesse Joyner,M,USA,00:51.7,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 200m,Yes,"IJA, Kentucky",Chloe Hirschowitz,F,USA,00:53.4,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,5b 100m,Yes,"IJA, Kentucky",Len Ferman,M,USA,00:56.9,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,5b 100m,Yes,"IJA, Kentucky",Gus Tate,M,USA,00:57.1,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 4x100m,Yes,"IJA, Kentucky","Gus Tate, Jesse Joyner, Matt Baum, Andrew Ruiz",M,#N/A,01:04.2,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 4x100m,Yes,"IJA, Kentucky","Chris Essick, Perry Romanowski, Jason Hollandsworth, Len Ferman",M,#N/A,01:06.0,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 400m,Yes,"IJA, Kentucky",Perry Romanowski,M,USA,01:06.5,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 4x100m,Yes,"IJA, Kentucky","Jeremy Stanley,Tim Hark, Cartier, Ron Zeszut",M,#N/A,01:07.0,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 400m,Yes,"IJA, Kentucky",Benjamin Thompson,M,0,01:09.2,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 400m,Yes,"IJA, Kentucky",Jason Hollandsworth,M,0,01:12.7,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 400m,Yes,"IJA, Kentucky",Tim Hark,M,0,01:13.0,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 400m,Yes,"IJA, Kentucky",Andrew Swan,M,0,01:15.6,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 4x100m,Yes,"IJA, Kentucky","Anders Kierulf, Jack Hirschowitz, Danny Tomaro",M,#N/A,01:16.0,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 4x100m,Yes,"IJA, Kentucky","Daniel Rose, Spicola, Bade, Colin Revere",M,#N/A,01:16.4,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 400m,Yes,"IJA, Kentucky",Anders Kierulf,M,0,01:16.5,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 4x100m,Yes,"IJA, Kentucky","Austin Bruckner, Nathan Biggs-Penton, Chloe Hirschowitz, Kyler McClintock",,#N/A,01:20.0,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 400m,Yes,"IJA, Kentucky",Mike Monson,M,0,01:22.2,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 400m,Yes,"IJA, Kentucky",Kyler McClintock,M,0,01:24.5,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 4x100m,Yes,"IJA, Kentucky","Andrew Swan, Mike Monson, Tom McClintock, Anthony",M,#N/A,01:25.0,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 400m,Yes,"IJA, Kentucky",Andrew Ruiz,M,0,01:33.7,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 400m,Yes,"IJA, Kentucky",Austin Bruckner,M,0,01:51.8,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 400m,Yes,"IJA, Kentucky",Nathan Biggs-Penton,M,0,01:58.0,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 400m,Yes,"IJA, Kentucky",Chloe Hirschowitz,F,USA,02:19.4,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 800m,Yes,"IJA, Kentucky",Len Ferman,M,USA,02:23.5,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 800m,Yes,"IJA, Kentucky",Perry Romanowski,M,USA,02:32.9,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 800m,Yes,"IJA, Kentucky",Matt Baum,M,0,02:52.6,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 800m,Yes,"IJA, Kentucky",Tim Hark,M,0,03:01.1,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 800m,Yes,"IJA, Kentucky",Anders Kierulf,M,0,03:06.2,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 800m,Yes,"IJA, Kentucky",Mike Monson,M,0,03:07.2,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 800m,Yes,"IJA, Kentucky",Andrew Swan,M,0,03:10.6,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 800m,Yes,"IJA, Kentucky",Kyler McClintock,M,0,03:13.5,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 800m,Yes,"IJA, Kentucky",Jeremy Stanley,M,0,03:14.0,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 800m,Yes,"IJA, Kentucky",Heather Marriott,F,USA,03:20.0,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 800m,Yes,"IJA, Kentucky",Nathan Biggs-Penton,M,0,04:12.0,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 4x400m,Yes,"IJA, Kentucky","Chris Essick, Perry Romanowski, Jason Hollandsworth, Len Ferman",M,#N/A,04:53.0,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 800m,Yes,"IJA, Kentucky",Austin Bruckner,M,0,05:20.0,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 4x400m,Yes,"IJA, Kentucky","Gus Tate, Jesse Joyner, Matt Baum, Andrew Ruiz",M,#N/A,05:30.3,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 1600m,No,"IJA, Kentucky",Len Ferman,M,USA,05:40.0,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 4x400m,Yes,"IJA, Kentucky","Andrew Swan, Mike Monson, Tom McClintock, Anders Kierulf",M,#N/A,05:44.0,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 4x400m,Yes,"IJA, Kentucky","Jeremy Stanley,Tim Hark, Cartier, Ron Zeszut",M,#N/A,05:46.0,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 4x400m,Yes,"IJA, Kentucky","Austin Bruckner, Nathan Biggs-Penton, Kyler McClintock",M,#N/A,07:16.0,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 4x400m,Yes,"IJA, Kentucky","Danny Tomaro, Jack Hirschowitz, Anthony",M,#N/A,07:21.0,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 1600m,No,"IJA, Kentucky",Perry Romanowski,M,USA,07:24.3,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 1600m,No,"IJA, Kentucky",Andrew Swan,M,0,07:46.8,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 1600m,No,"IJA, Kentucky",Tim Hark,M,0,07:58.0,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 1600m,No,"IJA, Kentucky",Anders Kierulf,M,0,08:23.5,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 1600m,No,"IJA, Kentucky",Jack Hirschowitz,M,USA,08:32.0,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 1600m,No,"IJA, Kentucky",Andrew Ruiz,M,0,09:07.0,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 1600m,No,"IJA, Kentucky",Ron Zeszut,M,0,09:40.0,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 1600m,No,"IJA, Kentucky",Nathan Biggs-Penton,M,0,10:52.0,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 1600m,No,"IJA, Kentucky",Austin Bruckner,M,0,11:59.0,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 5km,Yes,"IJA, Kentucky",Perry Romanowski,M,USA,21:50.0,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 5km,Yes,"IJA, Kentucky",Jesse Joyner,M,USA,24:24.0,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 5km,Yes,"IJA, Kentucky",Gus Tate,M,USA,24:31.0,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 5km,Yes,"IJA, Kentucky",Danny Tomaro,M,0,26:07.0,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 5km,Yes,"IJA, Kentucky",Andrew Swan,M,0,28:03.0,?,https://dev.juggle.org/history/champs/champs2008.php
+15/07/2008,2008,3b 5km,Yes,"IJA, Kentucky",Tom McClintock,M,0,29:20.0,?,https://dev.juggle.org/history/champs/champs2008.php
+22/06/2008,2008,3b 10km,Yes,Leeds 10km,Ralph Kidner,M,GBR,12:00.0,82,https://www.facebook.com/photo/?fbid=10231140425355467
+13/04/2008,2008,3b Marathon,Yes,London Marathon,Perry Romanowski,M,USA,35:36.0,?,https://marathonview.net/result/45354889
+14/10/2007,2007,3b Marathon,Yes,Munich Marathon,Peter Meyer,M,DEU,10:07.0,1,https://marathonview.net/search?query=peter%20meyer  http://home.mnet-online.de/joggling/aboutme_d.htm
+07/10/2007,2007,3b Marathon,Yes,Chicago Marathon,Perry Romanowski,M,USA,59:00.0,?,https://chicago-history.r.mikatiming.com/2021/?pid=search
+30/09/2007,2007,3b Marathon,Yes,Toronto Waterfront Marathon,Michal Kapral,M,CAN,50:12.0,2,
+17/07/2007,2007,3b 100m,Yes,"IJA, Winston-Salem",David Ferman,M,USA,00:14.8,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 100m,Yes,"IJA, Winston-Salem",Anders Kierulf,M,0,00:14.9,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 100m,Yes,"IJA, Winston-Salem",Nathan Vehse,M,0,00:15.1,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 100m,Yes,"IJA, Winston-Salem",Jeremy Stanley,M,0,00:15.5,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 100m,Yes,"IJA, Winston-Salem",Ricky Harr,M,0,00:15.8,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 100m,Yes,"IJA, Winston-Salem",Barry Goldmeier,M,USA,00:16.7,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 100m,Yes,"IJA, Winston-Salem",Andrew Swan,M,0,00:16.9,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 100m,Yes,"IJA, Winston-Salem",Aaron Rosenberg,M,0,00:20.2,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 100m,Yes,"IJA, Winston-Salem",Heather Marriott,F,USA,00:20.5,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 100m,Yes,"IJA, Winston-Salem",Christoph Mitasch,M,0,00:21.3,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 100m,Yes,"IJA, Winston-Salem",Matt Hall,M,0,00:22.0,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 100m,Yes,"IJA, Winston-Salem",Nicole Deese,F,0,00:22.0,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 100m,Yes,"IJA, Winston-Salem",Amanda Richter,F,0,00:22.0,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 100m,Yes,"IJA, Winston-Salem",Jeri Kalvan,F,0,00:23.4,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,5b 100m,Yes,"IJA, Winston-Salem",David Ferman,M,USA,00:24.3,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 100m,Yes,"IJA, Winston-Salem",Chloe Hirschowitz,F,USA,00:30.5,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 200m,Yes,"IJA, Winston-Salem",David Ferman,M,USA,00:31.8,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,5b 100m,Yes,"IJA, Winston-Salem",Barry Goldmeier,M,USA,00:32.5,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 100m,Yes,"IJA, Winston-Salem",Ethan Rosman,M,0,00:32.9,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 200m,Yes,"IJA, Winston-Salem",Aaron Rosenberg,M,0,00:32.9,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 200m,Yes,"IJA, Winston-Salem",Jeremy Stanley,M,0,00:32.9,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 200m,Yes,"IJA, Winston-Salem",Anders Kierulf,M,0,00:33.1,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 100m,Yes,"IJA, Winston-Salem",Ryan Schultz,M,0,00:33.1,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 200m,Yes,"IJA, Winston-Salem",Greg Warrington,M,0,00:33.3,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 200m,Yes,"IJA, Winston-Salem",Daniel Rose,M,0,00:35.4,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 100m,Yes,"IJA, Winston-Salem",Liana McClintock,F,0,00:36.0,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 200m,Yes,"IJA, Winston-Salem",Kyler McClintock,M,0,00:36.5,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 100m,Yes,"IJA, Winston-Salem",Sophia Rosman,F,0,00:39.7,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 200m,Yes,"IJA, Winston-Salem",Christoph Mitasch,M,0,00:40.2,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 200m,Yes,"IJA, Winston-Salem",Tom McClintock,M,0,00:40.2,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 200m,Yes,"IJA, Winston-Salem",Heather Marriott,F,USA,00:41.3,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,5b 100m,Yes,"IJA, Winston-Salem",Kyler McClintock,M,0,00:43.6,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,5b 100m,Yes,"IJA, Winston-Salem",Ricky Harr,M,0,00:45.1,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,5b 100m,Yes,"IJA, Winston-Salem",Brett Kissell,M,0,00:46.2,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 200m,Yes,"IJA, Winston-Salem",Nicole Deese,F,0,00:46.6,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,5b 100m,Yes,"IJA, Winston-Salem",Matt Hall,M,0,00:49.9,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 200m,Yes,"IJA, Winston-Salem",Chloe Hirschowitz,F,USA,00:54.6,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,5b 100m,Yes,"IJA, Winston-Salem",Greg Warrington,M,0,00:57.2,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,5b 100m,Yes,"IJA, Winston-Salem",Andrew Swan,M,0,00:59.6,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,5b 100m,Yes,"IJA, Winston-Salem",Christoph Mitasch,M,0,01:04.5,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,5b 100m,Yes,"IJA, Winston-Salem",Amanda Richter,F,0,01:05.4,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 400m,Yes,"IJA, Winston-Salem",Nathan Vehse,M,0,01:08.9,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 400m,Yes,"IJA, Winston-Salem",Greg Warrington,M,0,01:14.9,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 4x100m,Yes,"IJA, Winston-Salem","Nathan Vehse, Ron Zeszut, Tim Mauk, Jeremy Stanley",M,#N/A,01:15.8,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 400m,Yes,"IJA, Winston-Salem",Jeremy Stanley,M,0,01:17.6,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 400m,Yes,"IJA, Winston-Salem",Anders Kierulf,M,0,01:18.4,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 200m,Yes,"IJA, Winston-Salem",Ryan Schultz,M,0,01:18.6,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 400m,Yes,"IJA, Winston-Salem",David Ferman,M,USA,01:21.5,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 4x100m,Yes,"IJA, Winston-Salem","Tom McClintock, Jack Hirschowitz, Andy Swan, Anders Kierulf",M,#N/A,01:22.0,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 400m,Yes,"IJA, Winston-Salem",Broderick King,M,0,01:25.4,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 4x100m,Yes,"IJA, Winston-Salem","Broderick King, Scott Schultz, Colin Revere, Ricky Harr",M,#N/A,01:26.1,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 4x100m,Yes,"IJA, Winston-Salem","Len Ferman, Christoph Mitasch, Kylen McClintock, Andrew Ruiz",M,#N/A,01:26.2,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 400m,Yes,"IJA, Winston-Salem",Christoph Mitasch,M,0,01:26.4,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 400m,Yes,"IJA, Winston-Salem",Tom McClintock,M,0,01:29.3,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,5b 100m,Yes,"IJA, Winston-Salem",Heather Marriott,F,USA,01:31.0,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 400m,Yes,"IJA, Winston-Salem",Heather Marriott,F,USA,01:36.4,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 400m,Yes,"IJA, Winston-Salem",Jack Hirschowitz,M,USA,01:39.2,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 4x100m,Yes,"IJA, Winston-Salem","Ryan Schultz, Chloe Hirschowitz, David Ferman",,#N/A,01:40.7,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 400m,Yes,"IJA, Winston-Salem",Amanda Richter,F,0,01:56.1,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 400m,Yes,"IJA, Winston-Salem",Chloe Hirschowitz,F,USA,02:14.0,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 800m,Yes,"IJA, Winston-Salem",Len Ferman,M,USA,02:42.4,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 800m,Yes,"IJA, Winston-Salem",David Ferman,M,USA,02:49.7,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 800m,Yes,"IJA, Winston-Salem",Christoph Mitasch,M,0,02:50.7,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 800m,Yes,"IJA, Winston-Salem",Matt Hall,M,0,02:50.8,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,5b 100m,Yes,"IJA, Winston-Salem",Tom McClintock,M,0,03:01.0,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 4x400m,Yes,"IJA, Winston-Salem","Nathan Vehse, Ron Zeszut, Tim Mauk, Jeremy Stanley",M,#N/A,05:38.9,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 1600m,No,"IJA, Winston-Salem",Len Ferman,M,USA,05:46.5,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 4x400m,Yes,"IJA, Winston-Salem","Len Ferman, Christoph Mitasch, Kylen McClintock, Andrew Ruiz",M,#N/A,05:48.0,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 1600m,No,"IJA, Winston-Salem",Christoph Mitasch,M,0,06:10.2,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 4x400m,Yes,"IJA, Winston-Salem","Broderick King, Scott Schultz, Colin Revere, Ricky Harr",M,#N/A,06:18.8,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 4x400m,Yes,"IJA, Winston-Salem","Tom McClintock, Jack Hirschowitz, Andy Swan, Anders Kierulf",M,#N/A,07:12.3,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 1600m,No,"IJA, Winston-Salem",Jeri Kalvan,F,0,07:26.8,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 1600m,No,"IJA, Winston-Salem",Nicole Deese,F,0,07:54.4,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 1600m,No,"IJA, Winston-Salem",Tim Mauk,M,0,07:56.0,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 1600m,No,"IJA, Winston-Salem",David Ferman,M,USA,08:11.0,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 1600m,No,"IJA, Winston-Salem",Terry Odom,M,USA,08:14.0,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 1600m,No,"IJA, Winston-Salem",Tom McClintock,M,0,08:29.0,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 1600m,No,"IJA, Winston-Salem",Anders Kierulf,M,0,08:50.0,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 4x400m,Yes,"IJA, Winston-Salem","Ryan Schultz, Chloe Hirschowitz, David Ferman",,#N/A,10:01.0,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 5km,Yes,"IJA, Winston-Salem",Christoph Mitasch,M,0,22:27.0,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 5km,Yes,"IJA, Winston-Salem",Greg Warrington,M,0,24:34.0,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 5km,Yes,"IJA, Winston-Salem",Andrew Perrin,M,0,25:46.0,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 5km,Yes,"IJA, Winston-Salem",Terry Odom,M,USA,29:33.0,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,3b 5km,Yes,"IJA, Winston-Salem",Jack Hirschowitz,M,USA,32:50.0,?,https://dev.juggle.org/history/champs/champs2007.php
+17/07/2007,2007,5b 5km,Yes,"IJA, Winston-Salem",Barry Goldmeier,M,USA,38:58.0,?,https://dev.juggle.org/history/champs/champs2007.php
+17/06/2007,2007,3b Marathon,Yes,Fuerth Marathon,Ingbert Bittel,M,DEU,57:25.0,?,https://www.trackmyrace.com/en/running/event-zone/event/jahrtausend-marathon-fuerth/results/marathon/   https://www.teambittel.de/team/veranstaltungen_2007/20070617_fuerth.htm
+29/04/2007,2007,3b 5km,Yes,"Limestone 5K, Kingston, Ontario",Travis Saunders,M,CAN,17:05.0,?,https://thejoggler.blogspot.com/2007/05/saunders-just-misses-5k-joggling-record.html
+21/04/2007,2007,3b Marathon,Yes,Salt Lake City Marathon,Michal Kapral,M,CAN,53:28.0,4,
+21/04/2007,2007,3b Marathon,Yes,Salt Lake City Marathon,Zach Warren,M,USA,57:02.0,?,
+02/04/2007,2007,3b 10km,Yes,Lincoln 10km,Tim Butler,M,GBR,47:01.0,?,
+25/03/2007,2007,3b 30km,No,"Around The Bay 30k, Hamilton, Canada",Michal Kapral,M,CAN,54:44.0,4,https://thejoggler.blogspot.com/2007/03/joggling-around-bay.html      https://www.sportstats.ca/display-results.xhtml?raceid=8080&bib=15
+19/11/2006,2006,3b Marathon,Yes,Philadelphia Marathon,Zach Warren,M,USA,52:15.0,?,
+05/11/2006,2006,3b Marathon,Yes,New York City Marathon,Jonas Eberlein,M,DEU,13:31.0,?,https://marathonview.net/search?query=Jonas%20Eberlein  https://www.justyouraveragejoggler.com/jonas-eberlein-world-traveling-adventure-joggler/
+22/10/2006,2006,3b Marathon,Yes,Chicago Marathon,Perry Romanowski,M,USA,24:46.0,?,https://chicago-history.r.mikatiming.com/2021/?pid=search
+24/09/2006,2006,3b Marathon,Yes,Toronto Waterfront Marathon,Michal Kapral,M,CAN,57:44.0,8,
+24/09/2006,2006,3b Marathon,Yes,Toronto Waterfront Marathon,Perry Romanowski,M,USA,28:54.0,?,https://marathonview.net/result/53088739
+10/09/2006,2006,3b 10km,Yes,Toronto Island Run,Michal Kapral,M,CAN,36:27.0,?,
+18/07/2006,2006,3b 100m,Yes,"IJA, Portland, Oregon",Trey Newsome,M,0,00:14.0,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 100m,Yes,"IJA, Portland, Oregon",Riley Wiklund,M,0,00:14.9,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 100m,Yes,"IJA, Portland, Oregon",Anders Kierulf,M,0,00:15.1,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 100m,Yes,"IJA, Portland, Oregon",Sam Nerenhaus,M,0,00:16.1,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 100m,Yes,"IJA, Portland, Oregon",Mike Monson,M,0,00:16.6,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 100m,Yes,"IJA, Portland, Oregon",Marco Paoletti,M,0,00:16.9,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 100m,Yes,"IJA, Portland, Oregon",Tom McClintock,M,0,00:17.1,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 100m,Yes,"IJA, Portland, Oregon",Daniel Rose,M,0,00:17.1,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 100m,Yes,"IJA, Portland, Oregon",Kyler McClintock,M,0,00:17.6,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 100m,Yes,"IJA, Portland, Oregon",Colin Kulstad,M,0,00:20.0,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 100m,Yes,"IJA, Portland, Oregon",Jonny Langholz,M,0,00:20.0,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 100m,Yes,"IJA, Portland, Oregon",Lauren Rice,F,0,00:20.7,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 100m,Yes,"IJA, Portland, Oregon",Kelsey Harr,F,0,00:23.2,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 100m,Yes,"IJA, Portland, Oregon",Justin Kolas,M,0,00:23.3,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 100m,Yes,"IJA, Portland, Oregon",Amanda Richter,F,0,00:23.7,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 100m,Yes,"IJA, Portland, Oregon",Aubree Kolas,F,0,00:26.2,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 200m,Yes,"IJA, Portland, Oregon",Trey Newsome,M,0,00:29.5,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 200m,Yes,"IJA, Portland, Oregon",Marco Paoletti,M,0,00:32.2,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 200m,Yes,"IJA, Portland, Oregon",Anders Kierulf,M,0,00:32.8,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 200m,Yes,"IJA, Portland, Oregon",Tom McClintock,M,0,00:35.0,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 200m,Yes,"IJA, Portland, Oregon",Sam Nerenhaus,M,0,00:35.8,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 200m,Yes,"IJA, Portland, Oregon",Mike Monson,M,0,00:35.9,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 200m,Yes,"IJA, Portland, Oregon",Daniel Rose,M,0,00:36.8,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,5b 100m,Yes,"IJA, Portland, Oregon",Marco Paoletti,M,0,00:36.8,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 200m,Yes,"IJA, Portland, Oregon",Colin Revere,M,0,00:41.0,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 200m,Yes,"IJA, Portland, Oregon",Kyler McClintock,M,0,00:41.6,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 200m,Yes,"IJA, Portland, Oregon",Justin Kolas,M,0,00:44.1,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 200m,Yes,"IJA, Portland, Oregon",Colin Kulstad,M,0,00:46.9,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 200m,Yes,"IJA, Portland, Oregon",Amanda Richter,F,0,00:47.0,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,5b 100m,Yes,"IJA, Portland, Oregon",Kyler McClintock,M,0,00:48.3,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 200m,Yes,"IJA, Portland, Oregon",Zoe Roy,F,0,00:51.7,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,5b 100m,Yes,"IJA, Portland, Oregon",Sam Nerenhaus,M,0,00:52.3,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,5b 100m,Yes,"IJA, Portland, Oregon",Jonny Langholz,M,0,00:57.3,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 400m,Yes,"IJA, Portland, Oregon",Trey Newsome,M,0,01:01.0,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 200m,Yes,"IJA, Portland, Oregon",Aubree Kolas,F,0,01:01.4,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 400m,Yes,"IJA, Portland, Oregon",Marco Paoletti,M,0,01:09.0,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 4x100m,Yes,"IJA, Portland, Oregon","Lana Bolin, Kelsey Deutch, Sam Nerenhaus, Marco Paoletti",,#N/A,01:14.0,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,5b 100m,Yes,"IJA, Portland, Oregon",Lauren Rice,F,0,01:14.4,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,5b 100m,Yes,"IJA, Portland, Oregon",Amanda Richter,F,0,01:14.7,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 400m,Yes,"IJA, Portland, Oregon",Anders Kierulf,M,0,01:15.4,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 400m,Yes,"IJA, Portland, Oregon",Tom McClintock,M,0,01:16.0,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 400m,Yes,"IJA, Portland, Oregon",Sam Nerenhaus,M,0,01:17.0,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 400m,Yes,"IJA, Portland, Oregon",Mike Monson,M,0,01:18.0,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 400m,Yes,"IJA, Portland, Oregon",Riley Wiklund,M,0,01:20.0,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 400m,Yes,"IJA, Portland, Oregon",Kyle Barrett,M,0,01:23.0,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 4x100m,Yes,"IJA, Portland, Oregon","Kelsey Harr, Tom McClintock, Riley Wiklund, Bill Coad",,#N/A,01:24.0,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 400m,Yes,"IJA, Portland, Oregon",Lana Bolin,F,0,01:26.0,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 400m,Yes,"IJA, Portland, Oregon",Lauren Rice,F,0,01:29.0,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,5b 100m,Yes,"IJA, Portland, Oregon",Andrew Swan,M,0,01:29.5,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 4x100m,Yes,"IJA, Portland, Oregon","Riley Wiklund, Amanda Richter, Kelsey Harr, Lauren Rice",,#N/A,01:31.0,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 4x100m,Yes,"IJA, Portland, Oregon","Kyler McClintock, Aubree Kolas, Justin Kolas",,#N/A,01:32.0,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 400m,Yes,"IJA, Portland, Oregon",Sandy Brown,F,0,01:37.0,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 4x100m,Yes,"IJA, Portland, Oregon","Jonny Langholz, Daniel Rose, Colin Kulstud, Colin Revere",#N/A,#N/A,01:37.0,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 4x100m,Yes,"IJA, Portland, Oregon","Anders Kierulf, Danny Tomaro, Andrew Swan, Mike Monson",#N/A,#N/A,01:45.0,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 400m,Yes,"IJA, Portland, Oregon",Justin Kolas,M,0,01:51.0,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 400m,Yes,"IJA, Portland, Oregon",Amanda Richter,F,0,01:52.0,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 400m,Yes,"IJA, Portland, Oregon",Kelsey Harr,F,0,01:53.0,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,5b 100m,Yes,"IJA, Portland, Oregon",Bill Coad,M,USA,01:53.2,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 400m,Yes,"IJA, Portland, Oregon",Colin Kulstad,M,0,01:59.0,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 400m,Yes,"IJA, Portland, Oregon",Zoe Roy,F,0,02:13.0,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 400m,Yes,"IJA, Portland, Oregon",Aubree Kolas,F,0,02:16.0,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 800m,Yes,"IJA, Portland, Oregon",Trey Newsome,M,0,02:25.3,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,5b 100m,Yes,"IJA, Portland, Oregon",Tom McClintock,M,0,02:40.0,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 800m,Yes,"IJA, Portland, Oregon",Kyle Barrett,M,0,02:47.1,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 800m,Yes,"IJA, Portland, Oregon",Marco Paoletti,M,0,02:51.7,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 400m,Yes,"IJA, Portland, Oregon",Muffy Roy,F,0,03:05.0,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 800m,Yes,"IJA, Portland, Oregon",Tom McClintock,M,0,03:05.8,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 4x100m,Yes,"IJA, Portland, Oregon","Barry Goldmeier, Bill Coad",#N/A,#N/A,03:06.0,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 800m,Yes,"IJA, Portland, Oregon",Lauren Rice,F,0,03:08.0,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 800m,Yes,"IJA, Portland, Oregon",Heather Marriott,F,USA,03:10.0,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 800m,Yes,"IJA, Portland, Oregon",Mike Monson,M,0,03:13.1,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 800m,Yes,"IJA, Portland, Oregon",Anders Kierulf,M,0,03:16.8,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 800m,Yes,"IJA, Portland, Oregon",Riley Wiklund,M,0,03:19.2,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 800m,Yes,"IJA, Portland, Oregon",Kyler McClintock,M,0,03:21.3,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 800m,Yes,"IJA, Portland, Oregon",Zoe Roy,F,0,03:28.5,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 800m,Yes,"IJA, Portland, Oregon",Dean Bennett,M,0,03:51.6,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 800m,Yes,"IJA, Portland, Oregon",Justin Kolas,M,0,03:52.0,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 800m,Yes,"IJA, Portland, Oregon",Dorothy Finnigan,F,0,03:52.0,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 800m,Yes,"IJA, Portland, Oregon",Aubree Kolas,F,0,05:20.1,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 1600m,No,"IJA, Portland, Oregon",Trey Newsome,M,0,05:36.6,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 4x400m,Yes,"IJA, Portland, Oregon","Lana Bolin, Kelsey Deutch, Sam Nerenhaus, Marco Paoletti",#N/A,#N/A,05:43.5,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 4x400m,Yes,"IJA, Portland, Oregon","Danny Tomaro, Mike Monson, Tom McClintock, Anders Kierulf",#N/A,#N/A,05:45.9,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 1600m,No,"IJA, Portland, Oregon",Marco Paoletti,M,0,06:08.0,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 1600m,No,"IJA, Portland, Oregon",Kyle Barrett,M,0,06:10.5,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 4x400m,Yes,"IJA, Portland, Oregon","Lauren Rice, Zoe Roy, Dorothy Finigan, Kelsey Harr",#N/A,#N/A,06:11.0,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 1600m,No,"IJA, Portland, Oregon",Sam Nerenhaus,M,0,06:58.0,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 1600m,No,"IJA, Portland, Oregon",Tom McClintock,M,0,07:05.0,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 1600m,No,"IJA, Portland, Oregon",Anders Kierulf,M,0,07:29.0,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 4x400m,Yes,"IJA, Portland, Oregon","Kyler McClintock, Aubree Kolas, Justin Kolas, Colin Kulstad",#N/A,#N/A,07:45.0,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 4x400m,Yes,"IJA, Portland, Oregon","Bill Coad, Dean Bennett, Andrew Swan, Colin Revere",#N/A,#N/A,08:35.0,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 1600m,No,"IJA, Portland, Oregon",Bill Coad,M,USA,08:45.7,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 5km,Yes,"IJA, Portland, Oregon",Tosch Roy,M,0,20:01.0,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 5km,Yes,"IJA, Portland, Oregon",Kyle Barrett,M,0,21:25.0,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 5km,Yes,"IJA, Portland, Oregon",Danny Tomaro,M,0,25:27.0,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 5km,Yes,"IJA, Portland, Oregon",Tom McClintock,M,0,27:53.0,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 5km,Yes,"IJA, Portland, Oregon",Dean Bennett,M,0,28:30.0,?,https://dev.juggle.org/history/champs/champs2006.php
+18/07/2006,2006,3b 5km,Yes,"IJA, Portland, Oregon",Dorothy Finnigan,F,0,36:11.0,?,https://dev.juggle.org/history/champs/champs2006.php
+28/05/2006,2006,3b Marathon,Yes,Madison Marathon,Perry Romanowski,M,USA,56:56.0,?,
+21/05/2006,2006,3b Marathon,Yes,Heilbronner Trollinger Marathon,Ingbert Bittel,M,DEU,03:18.0,?,https://www.teambittel.de/team/veranstaltungen_2007/20070617_fuerth.htm  https://marathonview.net/search?query=Ingbert%20Bittel
+17/04/2006,2006,3b Marathon,Yes,Boston Marathon,Zach Warren,M,USA,58:23.0,?,
+17/04/2006,2006,3b Marathon,Yes,Boston Marathon,Michal Kapral,M,CAN,06:45.0,14,
+20/11/2005,2005,3b Marathon,Yes,Philadelphia Marathon,Zach Warren,M,USA,07:05.0,?,https://www.thecrimson.com/article/2005/11/30/marathon-man-grad-student-keeps-balls/
+06/11/2005,2005,3b Marathon,Yes,New York City Marathon,Perry Romanowski,M,USA,58:10.0,?,https://marathonview.net/result/31146807
+09/10/2005,2005,3b Marathon,Yes,Chicago Marathon,Perry Romanowski,M,USA,22:54.0,?,https://chicago-history.r.mikatiming.com/2021/?pid=search
+25/09/2005,2005,3b Marathon,Yes,Toronto Waterfront Marathon,Michal Kapral,M,CAN,07:46.0,20,
+19/07/2005,2005,3b 100m,Yes,"IJA, Davenport, Iowa",Chris Essick,M,0,00:14.2,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 100m,Yes,"IJA, Davenport, Iowa",Trey Newsome,M,0,00:14.4,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 100m,Yes,"IJA, Davenport, Iowa",Bernard Dehoog,M,0,00:15.9,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 100m,Yes,"IJA, Davenport, Iowa",Andrew Swan,M,0,00:16.3,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 100m,Yes,"IJA, Davenport, Iowa",Jeremy Stanley,M,0,00:16.7,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 100m,Yes,"IJA, Davenport, Iowa",Mike Monson,M,0,00:17.5,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 100m,Yes,"IJA, Davenport, Iowa",Jack Hirschowitz,M,USA,00:17.6,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 100m,Yes,"IJA, Davenport, Iowa",Ricky Harr,M,0,00:17.9,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 100m,Yes,"IJA, Davenport, Iowa",Kevin Beargie,M,0,00:18.5,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 100m,Yes,"IJA, Davenport, Iowa",Roy Fisher,M,0,00:20.3,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 100m,Yes,"IJA, Davenport, Iowa",Phillip Garee,M,0,00:20.5,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 100m,Yes,"IJA, Davenport, Iowa",Kyler McClintock,M,0,00:20.7,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 100m,Yes,"IJA, Davenport, Iowa",Nicole Deese,F,0,00:21.7,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 100m,Yes,"IJA, Davenport, Iowa",Dan Rosenthal,M,0,00:23.9,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 100m,Yes,"IJA, Davenport, Iowa",Broderick King,M,0,00:25.0,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 100m,Yes,"IJA, Davenport, Iowa",Jonny Langholz,M,0,00:25.9,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 100m,Yes,"IJA, Davenport, Iowa",Ben Hestness,M,0,00:26.0,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 100m,Yes,"IJA, Davenport, Iowa",Tom McClintock,M,0,00:27.1,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 100m,Yes,"IJA, Davenport, Iowa",Todd Warner,M,0,00:28.6,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 200m,Yes,"IJA, Davenport, Iowa",Trey Newsome,M,0,00:28.7,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,5b 100m,Yes,"IJA, Davenport, Iowa",Ben Schoenberg,M,0,00:30.1,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 100m,Yes,"IJA, Davenport, Iowa",Silas Wallen-Friedman,M,0,00:35.2,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 200m,Yes,"IJA, Davenport, Iowa",Roy Fisher,M,0,00:37.2,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 200m,Yes,"IJA, Davenport, Iowa",Andrew Swan,M,0,00:37.7,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 200m,Yes,"IJA, Davenport, Iowa",Mike Monson,M,0,00:37.9,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 200m,Yes,"IJA, Davenport, Iowa",Jeremy Stanley,M,0,00:38.2,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 100m,Yes,"IJA, Davenport, Iowa",Brendan McCarthy,M,0,00:38.5,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 200m,Yes,"IJA, Davenport, Iowa",Chris Essick,M,0,00:40.1,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,5b 100m,Yes,"IJA, Davenport, Iowa",Andrew Swan,M,0,00:43.5,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,5b 100m,Yes,"IJA, Davenport, Iowa",Trey Newsome,M,0,00:45.1,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 200m,Yes,"IJA, Davenport, Iowa",Tom McClintock,M,0,00:45.8,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 100m,Yes,"IJA, Davenport, Iowa",Rebecca Middleton,F,0,00:48.2,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 100m,Yes,"IJA, Davenport, Iowa",Alex Coleman,M,0,00:49.3,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 200m,Yes,"IJA, Davenport, Iowa",Kyler McClintock,M,0,00:52.4,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,5b 100m,Yes,"IJA, Davenport, Iowa",Ricky Harr,M,0,01:00.5,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 400m,Yes,"IJA, Davenport, Iowa",Trey Newsome,M,0,01:04.6,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,5b 100m,Yes,"IJA, Davenport, Iowa",Silas Wallen-Friedman,M,0,01:07.1,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 100m,Yes,"IJA, Davenport, Iowa",Joy Dean,F,0,01:09.2,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 200m,Yes,"IJA, Davenport, Iowa",Brendan McCarthy,M,0,01:11.3,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 400m,Yes,"IJA, Davenport, Iowa",Chris Essick,M,0,01:14.0,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 200m,Yes,"IJA, Davenport, Iowa",Rebecca Middleton,F,0,01:15.7,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,5b 100m,Yes,"IJA, Davenport, Iowa",Ben Hestness,M,0,01:16.3,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 4x100m,Yes,"IJA, Davenport, Iowa","Mike Monson, Andrew Swan, Danny Tomaro, Jack Hirschowitz",#N/A,#N/A,01:17.0,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,5b 100m,Yes,"IJA, Davenport, Iowa",Bernard Dehoog,M,0,01:21.4,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 200m,Yes,"IJA, Davenport, Iowa",Alex Coleman,M,0,01:21.8,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 400m,Yes,"IJA, Davenport, Iowa",Andrew Swan,M,0,01:22.9,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 400m,Yes,"IJA, Davenport, Iowa",Mike Monson,M,0,01:24.0,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 4x100m,Yes,"IJA, Davenport, Iowa","Tom McClintock, Joey Newsome, Trey Newsome, Chris Essick",#N/A,#N/A,01:25.0,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 4x100m,Yes,"IJA, Davenport, Iowa","Jonny Langholz, Ben Hestness, Kyler McClintock, Silas Wallen-Friedman",#N/A,#N/A,01:31.5,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 400m,Yes,"IJA, Davenport, Iowa",Tom McClintock,M,0,01:36.5,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 400m,Yes,"IJA, Davenport, Iowa",Roy Fisher,M,0,01:37.4,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 400m,Yes,"IJA, Davenport, Iowa",Kevin Beargie,M,0,01:44.9,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 400m,Yes,"IJA, Davenport, Iowa",Kyler McClintock,M,0,01:45.0,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 4x100m,Yes,"IJA, Davenport, Iowa","Kevin Beargie, Phillip Garee, Todd Warner, Brendan McCarthy",#N/A,#N/A,01:47.2,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 400m,Yes,"IJA, Davenport, Iowa",Jeremy Stanley,M,0,01:53.4,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 400m,Yes,"IJA, Davenport, Iowa",Broderick King,M,0,02:02.4,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 400m,Yes,"IJA, Davenport, Iowa",Silas Wallen-Friedman,M,0,02:16.6,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 200m,Yes,"IJA, Davenport, Iowa",Joy Dean,F,0,02:21.8,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 4x200m,No,"IJA, Davenport, Iowa","Trey Newsome, Chris Essick, Jonny Langholz, Roy Fisher",#N/A,#N/A,02:27.9,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 400m,Yes,"IJA, Davenport, Iowa",Rebecca Middleton,F,0,02:35.6,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 800m,Yes,"IJA, Davenport, Iowa",Trey Newsome,M,0,02:36.3,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 4x200m,No,"IJA, Davenport, Iowa","Mike Monson, Andrew Swan, Danny Tomaro, Jack Hirschowitz",#N/A,#N/A,02:38.0,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 800m,Yes,"IJA, Davenport, Iowa",Bernard Dehoog,M,0,03:10.7,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 4x200m,No,"IJA, Davenport, Iowa","Bernard Dehoog, Ricky Harr, Dan Rosenthal, Broderick King",#N/A,#N/A,03:12.0,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 800m,Yes,"IJA, Davenport, Iowa",Mike Monson,M,0,03:22.3,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 4x200m,No,"IJA, Davenport, Iowa","Kevin Beargie, Phillip Garee, Todd Warner, Alex Coleman",#N/A,#N/A,03:23.0,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 800m,Yes,"IJA, Davenport, Iowa",Danny Tomaro,M,0,03:31.6,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 800m,Yes,"IJA, Davenport, Iowa",Roy Fisher,M,0,03:32.0,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 800m,Yes,"IJA, Davenport, Iowa",Jack Hirschowitz,M,USA,03:45.5,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 800m,Yes,"IJA, Davenport, Iowa",Nicole Deese,F,0,03:47.4,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 800m,Yes,"IJA, Davenport, Iowa",Phillip Garee,M,0,03:49.0,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 800m,Yes,"IJA, Davenport, Iowa",Tom McClintock,M,0,03:52.0,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 4x200m,No,"IJA, Davenport, Iowa","Jonny Langholz, Ben Hestness, Kyler McClintock, Silas Wallen-Friedman",#N/A,#N/A,03:54.0,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 800m,Yes,"IJA, Davenport, Iowa",Kyler McClintock,M,0,03:56.0,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 800m,Yes,"IJA, Davenport, Iowa",Todd Warner,M,0,04:01.0,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 800m,Yes,"IJA, Davenport, Iowa",Jeremy Stanley,M,0,04:12.0,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 800m,Yes,"IJA, Davenport, Iowa",Dan Rosenthal,M,0,04:19.0,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 800m,Yes,"IJA, Davenport, Iowa",Kevin Beargie,M,0,04:21.0,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 1600m,No,"IJA, Davenport, Iowa",Trey Newsome,M,0,06:41.2,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 1600m,No,"IJA, Davenport, Iowa",Danny Tomaro,M,0,07:23.2,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 1600m,No,"IJA, Davenport, Iowa",Mike Monson,M,0,07:56.4,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 1600m,No,"IJA, Davenport, Iowa",Todd Warner,M,0,08:01.7,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 1600m,No,"IJA, Davenport, Iowa",Jack Hirschowitz,M,USA,08:31.9,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 1600m,No,"IJA, Davenport, Iowa",Nicole Deese,F,0,08:41.2,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 1600m,No,"IJA, Davenport, Iowa",Tom McClintock,M,0,09:04.0,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 1600m,No,"IJA, Davenport, Iowa",Broderick King,M,0,11:18.0,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 1600m,No,"IJA, Davenport, Iowa",Elliot Royce,M,0,23:23.0,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 5km,Yes,"IJA, Davenport, Iowa",Danny Tomaro,M,0,26:46.0,?,https://dev.juggle.org/history/champs/champs2005.php
+19/07/2005,2005,3b 5km,Yes,"IJA, Davenport, Iowa",Todd Warner,M,0,38:11.0,?,https://dev.juggle.org/history/champs/champs2005.php
+07/05/2005,2005,3b 5km,Yes,St Paul's Spring Tune-up,Riley McLincha,M,USA,26:20.0,3,https://www.athlinks.com/event/138944/results/Event/24014/Course/36946/Bib/708
+09/01/2005,2005,3b Marathon,Yes,Rock 'n' Roll Arizona,Perry Romanowski,M,USA,28:01.0,?,https://marathonview.net/result/61221540
+10/10/2004,2004,3b Marathon,Yes,Chicago Marathon,Perry Romanowski,M,USA,25:49.0,?,https://chicago-history.r.mikatiming.com/2021/?pid=search
+26/09/2004,2004,3b Marathon,Yes,Berlin Marathon,Peter Meyer,M,DEU,47:47.0,2,https://marathonview.net/search?query=peter%20meyer  http://home.mnet-online.de/joggling/aboutme_d.htm
+13/07/2004,2004,3b 100m,Yes,"IJA, Buffalo",Trey Newsome,M,0,00:15.3,?,https://dev.juggle.org/history/champs/champs2004.php
+13/07/2004,2004,3b 100m,Yes,"IJA, Buffalo",Ben Schoenberg,M,0,00:15.7,?,https://dev.juggle.org/history/champs/champs2004.php
+13/07/2004,2004,3b 100m,Yes,"IJA, Buffalo",Nick Pavlak,M,0,00:15.9,?,https://dev.juggle.org/history/champs/champs2004.php
+13/07/2004,2004,3b 100m,Yes,"IJA, Buffalo",Dan Tasse,M,0,00:16.1,?,https://dev.juggle.org/history/champs/champs2004.php
+13/07/2004,2004,3b 100m,Yes,"IJA, Buffalo",Gabe Jakubisin,M,0,00:16.4,?,https://dev.juggle.org/history/champs/champs2004.php
+13/07/2004,2004,3b 100m,Yes,"IJA, Buffalo",Bronwyn Neeser,F,0,00:17.7,?,https://dev.juggle.org/history/champs/champs2004.php
+13/07/2004,2004,3b 100m,Yes,"IJA, Buffalo",Andrew Swan,M,0,00:18.1,?,https://dev.juggle.org/history/champs/champs2004.php
+13/07/2004,2004,3b 100m,Yes,"IJA, Buffalo",Dorothy Finnigan,F,0,00:19.9,?,https://dev.juggle.org/history/champs/champs2004.php
+13/07/2004,2004,3b 100m,Yes,"IJA, Buffalo",Gil Pontius,M,0,00:20.3,?,https://dev.juggle.org/history/champs/champs2004.php
+13/07/2004,2004,3b 100m,Yes,"IJA, Buffalo",Carlos Nieves,M,0,00:20.5,?,https://dev.juggle.org/history/champs/champs2004.php
+13/07/2004,2004,3b 100m,Yes,"IJA, Buffalo",Becky Kresser,F,0,00:21.3,?,https://dev.juggle.org/history/champs/champs2004.php
+13/07/2004,2004,5b 100m,Yes,"IJA, Buffalo",Ben Schoenberg,M,0,00:24.3,?,https://dev.juggle.org/history/champs/champs2004.php
+13/07/2004,2004,5b 100m,Yes,"IJA, Buffalo",Billy Matsumoto,M,0,00:29.0,?,https://dev.juggle.org/history/champs/champs2004.php
+13/07/2004,2004,3b 100m,Yes,"IJA, Buffalo",Jeremy Stanley,M,0,00:31.8,?,https://dev.juggle.org/history/champs/champs2004.php
+13/07/2004,2004,5b 100m,Yes,"IJA, Buffalo",Peter Morris,M,0,00:44.3,?,https://dev.juggle.org/history/champs/champs2004.php
+13/07/2004,2004,5b 100m,Yes,"IJA, Buffalo",Andrew Swan,M,0,00:46.7,?,https://dev.juggle.org/history/champs/champs2004.php
+13/07/2004,2004,3b 4x100m,Yes,"IJA, Buffalo","Matt Diffee, Trey Newsom, Jamie Whoolery, Chris Essick",#N/A,#N/A,00:58.1,?,https://dev.juggle.org/history/champs/champs2004.php
+13/07/2004,2004,5b 100m,Yes,"IJA, Buffalo",Trey Newsome,M,0,00:59.5,?,https://dev.juggle.org/history/champs/champs2004.php
+13/07/2004,2004,3b 400m,Yes,"IJA, Buffalo",Matt Diffee,M,0,01:02.5,?,https://dev.juggle.org/history/champs/champs2004.php
+13/07/2004,2004,3b 400m,Yes,"IJA, Buffalo",Chris Essick,M,0,01:03.1,?,https://dev.juggle.org/history/champs/champs2004.php
+13/07/2004,2004,3b 400m,Yes,"IJA, Buffalo",Jamie Whoolery,M,0,01:05.1,?,https://dev.juggle.org/history/champs/champs2004.php
+13/07/2004,2004,3b 4x100m,Yes,"IJA, Buffalo","F Kennard, Ben Oldenburg, K Beargie, Dan Tasse",#N/A,#N/A,01:08.0,?,https://dev.juggle.org/history/champs/champs2004.php
+13/07/2004,2004,3b 400m,Yes,"IJA, Buffalo",Trey Newsome,M,0,01:10.0,?,https://dev.juggle.org/history/champs/champs2004.php
+13/07/2004,2004,3b 400m,Yes,"IJA, Buffalo",Gabe Jakubisin,M,0,01:11.0,?,https://dev.juggle.org/history/champs/champs2004.php
+13/07/2004,2004,3b 4x100m,Yes,"IJA, Buffalo","B. Gadomski, Pavlak, Bacchus, Gabe Jakubisin",#N/A,#N/A,01:15.4,?,https://dev.juggle.org/history/champs/champs2004.php
+13/07/2004,2004,3b 4x100m,Yes,"IJA, Buffalo","Anders Kierulf, Gil Pontius, Jack Hirschowitz, Andrew Swan",#N/A,#N/A,01:18.2,?,https://dev.juggle.org/history/champs/champs2004.php
+13/07/2004,2004,3b 400m,Yes,"IJA, Buffalo",Anders Kierulf,M,0,01:19.6,?,https://dev.juggle.org/history/champs/champs2004.php
+13/07/2004,2004,3b 4x100m,Yes,"IJA, Buffalo","Laura Kaseman, Dorothy Finnigan, Becky Kresser, Bronwyn Neeser",#N/A,#N/A,01:21.5,?,https://dev.juggle.org/history/champs/champs2004.php
+13/07/2004,2004,3b 400m,Yes,"IJA, Buffalo",Mike Monson,M,0,01:24.0,?,https://dev.juggle.org/history/champs/champs2004.php
+13/07/2004,2004,3b 400m,Yes,"IJA, Buffalo",Jack Hirschowitz,M,USA,01:25.0,?,https://dev.juggle.org/history/champs/champs2004.php
+13/07/2004,2004,3b 400m,Yes,"IJA, Buffalo",Bronwyn Neeser,F,0,01:29.9,?,https://dev.juggle.org/history/champs/champs2004.php
+13/07/2004,2004,3b 400m,Yes,"IJA, Buffalo",Nick Pavlak,M,0,01:30.1,?,https://dev.juggle.org/history/champs/champs2004.php
+13/07/2004,2004,5b 100m,Yes,"IJA, Buffalo",Dorothy Finnigan,F,0,01:30.6,?,https://dev.juggle.org/history/champs/champs2004.php
+13/07/2004,2004,3b 400m,Yes,"IJA, Buffalo",Dorothy Finnigan,F,0,01:33.2,?,https://dev.juggle.org/history/champs/champs2004.php
+13/07/2004,2004,5b 100m,Yes,"IJA, Buffalo",Bronwyn Neeser,F,0,01:35.0,?,https://dev.juggle.org/history/champs/champs2004.php
+13/07/2004,2004,3b 400m,Yes,"IJA, Buffalo",Laura Kaseman,F,0,01:52.0,?,https://dev.juggle.org/history/champs/champs2004.php
+13/07/2004,2004,3b 400m,Yes,"IJA, Buffalo",Carlos Nieves,M,0,01:53.7,?,https://dev.juggle.org/history/champs/champs2004.php
+13/07/2004,2004,5b 100m,Yes,"IJA, Buffalo",Laura Kaseman,F,0,02:01.0,?,https://dev.juggle.org/history/champs/champs2004.php
+13/07/2004,2004,3b 400m,Yes,"IJA, Buffalo",Jeremy Stanley,M,0,02:14.5,?,https://dev.juggle.org/history/champs/champs2004.php
+13/07/2004,2004,3b 4x100m,Yes,"IJA, Buffalo","S. Rogal, K. McGrath, M. Stockhausen, A. Wyszynski",#N/A,#N/A,02:14.5,?,https://dev.juggle.org/history/champs/champs2004.php
+13/07/2004,2004,3b 800m,Yes,"IJA, Buffalo",Jamie Whoolery,M,0,02:35.3,?,https://dev.juggle.org/history/champs/champs2004.php
+13/07/2004,2004,3b 800m,Yes,"IJA, Buffalo",Chris Essick,M,0,02:45.8,?,https://dev.juggle.org/history/champs/champs2004.php
+13/07/2004,2004,3b 800m,Yes,"IJA, Buffalo",Trey Newsome,M,0,02:54.3,?,https://dev.juggle.org/history/champs/champs2004.php
+13/07/2004,2004,3b 800m,Yes,"IJA, Buffalo",Gabe Jakubisin,M,0,02:57.4,?,https://dev.juggle.org/history/champs/champs2004.php
+13/07/2004,2004,3b 800m,Yes,"IJA, Buffalo",Dan Tasse,M,0,03:12.0,?,https://dev.juggle.org/history/champs/champs2004.php
+13/07/2004,2004,3b 800m,Yes,"IJA, Buffalo",Andrew Swan,M,0,03:22.5,?,https://dev.juggle.org/history/champs/champs2004.php
+13/07/2004,2004,3b 800m,Yes,"IJA, Buffalo",Nick Pavlak,M,0,03:24.7,?,https://dev.juggle.org/history/champs/champs2004.php
+13/07/2004,2004,3b 800m,Yes,"IJA, Buffalo",Mike Monson,M,0,03:25.0,?,https://dev.juggle.org/history/champs/champs2004.php
+13/07/2004,2004,3b 800m,Yes,"IJA, Buffalo",Anders Kierulf,M,0,03:27.5,?,https://dev.juggle.org/history/champs/champs2004.php
+13/07/2004,2004,3b 800m,Yes,"IJA, Buffalo",Becky Kresser,F,0,04:15.0,?,https://dev.juggle.org/history/champs/champs2004.php
+13/07/2004,2004,3b 800m,Yes,"IJA, Buffalo",Laura Kaseman,F,0,04:17.0,?,https://dev.juggle.org/history/champs/champs2004.php
+13/07/2004,2004,3b 4x400m,Yes,"IJA, Buffalo","Matt Diffee, Trey Newsom, Jamie Whoolery, Chris Essick",#N/A,#N/A,04:50.0,?,https://dev.juggle.org/history/champs/champs2004.php
+13/07/2004,2004,3b 4x400m,Yes,"IJA, Buffalo","Anders Kierulf, Gil Pontius, Jack Hirschowitz, Andrew Swan",#N/A,#N/A,06:21.0,?,https://dev.juggle.org/history/champs/champs2004.php
+13/07/2004,2004,3b 1600m,No,"IJA, Buffalo",Jamie Whoolery,M,0,06:38.0,?,https://dev.juggle.org/history/champs/champs2004.php
+13/07/2004,2004,3b 4x400m,Yes,"IJA, Buffalo","F Kennard, Ben Oldenburg, K Beargie, Dan Tasse",#N/A,#N/A,06:42.0,?,https://dev.juggle.org/history/champs/champs2004.php
+13/07/2004,2004,3b 1600m,No,"IJA, Buffalo",Chris Essick,M,0,07:18.9,?,https://dev.juggle.org/history/champs/champs2004.php
+13/07/2004,2004,3b 1600m,No,"IJA, Buffalo",Gabe Jakubisin,M,0,07:22.0,?,https://dev.juggle.org/history/champs/champs2004.php
+13/07/2004,2004,3b 1600m,No,"IJA, Buffalo",Andrew Swan,M,0,07:30.0,?,https://dev.juggle.org/history/champs/champs2004.php
+13/07/2004,2004,3b 1600m,No,"IJA, Buffalo",Mike Monson,M,0,07:35.0,?,https://dev.juggle.org/history/champs/champs2004.php
+13/07/2004,2004,3b 1600m,No,"IJA, Buffalo",David Chandler,M,0,08:30.0,?,https://dev.juggle.org/history/champs/champs2004.php
+13/07/2004,2004,3b 1600m,No,"IJA, Buffalo",Ben Oldenburg,M,0,08:59.0,?,https://dev.juggle.org/history/champs/champs2004.php
+13/07/2004,2004,3b 5km,Yes,"IJA, Buffalo",Jamie Whoolery,M,0,26:16.0,?,https://dev.juggle.org/history/champs/champs2004.php
+13/07/2004,2004,3b 5km,Yes,"IJA, Buffalo",Andrew Swan,M,0,29:15.0,?,https://dev.juggle.org/history/champs/champs2004.php
+13/07/2004,2004,3b 5km,Yes,"IJA, Buffalo",Dorothy Finnigan,F,0,35:49.0,?,https://dev.juggle.org/history/champs/champs2004.php
+06/06/2004,2004,3b Marathon,Yes,San Diego Rock 'n' Roll,Perry Romanowski,M,USA,59:51.0,?,https://marathonview.net/result/60090344
+11/01/2004,2004,3b Marathon,Yes,Rock 'n' Roll Arizona,Perry Romanowski,M,USA,50:21.0,?,https://marathonview.net/result/61212976
+05/10/2003,2003,3b Marathon,Yes,"Twin Cities Marathon, Minnesota",Perry Romanowski,M,USA,51:38.0,?,
+31/05/2003,2003,3b 10km,Yes,Oak Apple Run,Riley McLincha,M,USA,47:45.0,6,https://www.athlinks.com/event/28458/results/Event/59571/Course/362940/Entry/139702147
+28/04/2003,2003,3b Marathon,Yes,Cleveland Marathon,Perry Romanowski,M,USA,12:56.0,?,
+27/04/2003,2003,3b Half Marathon,Yes,West Bloomfield 1/2 Marathon,Riley McLincha,M,USA,12:42.0,15,https://www.athlinks.com/event/38318/results/Event/12960/Course/19137/Entry/8202460
+01/02/2003,2003,3b Mile,Yes,"Atlanta, Georgia",Will Howard,M,USA,04:42.0,?,http://www.atlantajugglers.org/aja-media/articles-by-our-members/86-joggling-world-record
+06/10/2002,2002,3b Marathon,Yes,Milwaukee Marathon,Perry Romanowski,M,USA,11:48.0,?,
+17/07/2002,2002,3b 100m,Yes,"IJA, Reading, Pennsylvania",Chris Essick,M,0,00:12.7,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 100m,Yes,"IJA, Reading, Pennsylvania",Albert Lucas,M,USA,00:12.7,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 100m,Yes,"IJA, Reading, Pennsylvania",Sam Hartford,M,0,00:14.5,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,5b 100m,Yes,"IJA, Reading, Pennsylvania",Albert Lucas,M,USA,00:15.5,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 100m,Yes,"IJA, Reading, Pennsylvania",Andrew Swan,M,0,00:16.0,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 100m,Yes,"IJA, Reading, Pennsylvania",Marlin Ballard,M,0,00:16.3,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 100m,Yes,"IJA, Reading, Pennsylvania",Chris Laco,M,0,00:16.5,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 100m,Yes,"IJA, Reading, Pennsylvania",Gil Pontius,M,0,00:17.1,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,5b 100m,Yes,"IJA, Reading, Pennsylvania",Sam Hartford,M,0,00:18.1,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 100m,Yes,"IJA, Reading, Pennsylvania",Jake Immerman,M,0,00:18.1,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 100m,Yes,"IJA, Reading, Pennsylvania",Heather Marriott,F,USA,00:19.1,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 100m,Yes,"IJA, Reading, Pennsylvania",Dorothy Finnigan,F,0,00:19.7,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 100m,Yes,"IJA, Reading, Pennsylvania",Paul Ballard,M,0,00:20.6,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 200m,Yes,"IJA, Reading, Pennsylvania",Chris Essick,M,0,00:26.5,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 200m,Yes,"IJA, Reading, Pennsylvania",Albert Lucas,M,USA,00:27.0,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,5b 100m,Yes,"IJA, Reading, Pennsylvania",Barry Goldmeier,M,USA,00:29.0,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 200m,Yes,"IJA, Reading, Pennsylvania",Sam Hartford,M,0,00:30.6,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 200m,Yes,"IJA, Reading, Pennsylvania",Barry Goldmeier,M,USA,00:32.3,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,5b 100m,Yes,"IJA, Reading, Pennsylvania",Marlin Ballard,M,0,00:33.6,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 100m,Yes,"IJA, Reading, Pennsylvania",Geoff Kennard,M,0,00:36.5,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 200m,Yes,"IJA, Reading, Pennsylvania",Marlin Ballard,M,0,00:38.7,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 200m,Yes,"IJA, Reading, Pennsylvania",Andrew Swan,M,0,00:39.2,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 200m,Yes,"IJA, Reading, Pennsylvania",Chris Laco,M,0,00:39.5,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 200m,Yes,"IJA, Reading, Pennsylvania",Zach Waickman,M,0,00:40.4,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 200m,Yes,"IJA, Reading, Pennsylvania",Jack Hirschowitz,M,USA,00:42.0,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 200m,Yes,"IJA, Reading, Pennsylvania",Benjamin Thompson,M,0,00:42.3,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,5b 100m,Yes,"IJA, Reading, Pennsylvania",Heather Marriott,F,USA,00:42.8,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 200m,Yes,"IJA, Reading, Pennsylvania",Dorothy Finnigan,F,0,00:44.6,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 200m,Yes,"IJA, Reading, Pennsylvania",Paul Ballard,M,0,00:45.2,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 200m,Yes,"IJA, Reading, Pennsylvania",Danny Tomaro,M,0,00:45.2,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,5b 100m,Yes,"IJA, Reading, Pennsylvania",Andrew Swan,M,0,00:49.0,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 200m,Yes,"IJA, Reading, Pennsylvania",Geoff Kennard,M,0,00:59.8,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 4x100m,Yes,"IJA, Reading, Pennsylvania","Albert Lucas, Sam Hartford, Jamie Whoolery, Chris Essick",#N/A,#N/A,00:59.8,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 400m,Yes,"IJA, Reading, Pennsylvania",Chris Essick,M,0,01:00.6,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 400m,Yes,"IJA, Reading, Pennsylvania",Jamie Whoolery,M,0,01:04.3,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 400m,Yes,"IJA, Reading, Pennsylvania",Nicholas Souren,M,0,01:07.2,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 400m,Yes,"IJA, Reading, Pennsylvania",Andrew Swan,M,0,01:10.6,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 400m,Yes,"IJA, Reading, Pennsylvania",Dan Peterson,M,0,01:17.5,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 4x100m,Yes,"IJA, Reading, Pennsylvania","Chris Laco, Geoff Kennard, Zach Waickman, Bacchus",#N/A,#N/A,01:18.9,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 400m,Yes,"IJA, Reading, Pennsylvania",Chris Laco,M,0,01:20.9,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 200m,Yes,"IJA, Reading, Pennsylvania",Rhonda Samkoff,F,0,01:21.4,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 4x100m,Yes,"IJA, Reading, Pennsylvania","Jack Hirschowitz, Andrew Swan, Marlin Ballard, Paul Ballard",#N/A,#N/A,01:22.2,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 400m,Yes,"IJA, Reading, Pennsylvania",Chris Sutton,M,0,01:24.7,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 200m,Yes,"IJA, Reading, Pennsylvania",Zoe Roy,F,0,01:25.4,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 400m,Yes,"IJA, Reading, Pennsylvania",Heather Marriott,F,USA,01:25.6,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 400m,Yes,"IJA, Reading, Pennsylvania",Jack Hirschowitz,M,USA,01:27.9,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 400m,Yes,"IJA, Reading, Pennsylvania",Paul Ballard,M,0,01:35.6,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 400m,Yes,"IJA, Reading, Pennsylvania",Jake Immerman,M,0,01:35.6,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 200m,Yes,"IJA, Reading, Pennsylvania",Muffy Roy,F,0,01:36.7,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 400m,Yes,"IJA, Reading, Pennsylvania",Danny Tomaro,M,0,01:37.1,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 400m,Yes,"IJA, Reading, Pennsylvania",Benjamin Thompson,M,0,01:38.9,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 400m,Yes,"IJA, Reading, Pennsylvania",Dorothy Finnigan,F,0,01:45.6,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 4x200m,No,"IJA, Reading, Pennsylvania","Barry Goldmeier, Jamie Whoolery, Chris Essick, Sam Hartford",#N/A,#N/A,02:10.5,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 400m,Yes,"IJA, Reading, Pennsylvania",Zoe Roy,F,0,02:26.5,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 4x200m,No,"IJA, Reading, Pennsylvania","Jack Hirschowitz, Gus Pontius, Marlin Ballard, Andrew Swan",#N/A,#N/A,02:48.1,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 400m,Yes,"IJA, Reading, Pennsylvania",Rhonda Samkoff,F,0,02:48.3,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 4x200m,No,"IJA, Reading, Pennsylvania","Chris Laco, Geoff Kennard, Zach Waickman, Bacchus",#N/A,#N/A,02:56.4,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 4x400m,Yes,"IJA, Reading, Pennsylvania","Barry Goldmeier, Jamie Whoolery, Chris Essick, Sam Hartford",#N/A,#N/A,04:42.6,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 1600m,No,"IJA, Reading, Pennsylvania",Mike Hebebrand,M,USA,05:42.9,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 1600m,No,"IJA, Reading, Pennsylvania",Jamie Whoolery,M,0,05:56.0,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 1600m,No,"IJA, Reading, Pennsylvania",Sam Hartford,M,0,06:11.0,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 4x400m,Yes,"IJA, Reading, Pennsylvania","Jack Hirschowitz, Gus Pontius, Marlin Ballard, Andrew Swan",#N/A,#N/A,06:15.6,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 1600m,No,"IJA, Reading, Pennsylvania",Jake Immerman,M,0,07:10.0,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 1600m,No,"IJA, Reading, Pennsylvania",Andrew Swan,M,0,07:19.0,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 1600m,No,"IJA, Reading, Pennsylvania",Jack Hirschowitz,M,USA,08:02.0,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 1600m,No,"IJA, Reading, Pennsylvania",Chris Sutton,M,0,08:36.0,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 5km,Yes,"IJA, Reading, Pennsylvania",Mike Hebebrand,M,USA,19:52.0,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 5km,Yes,"IJA, Reading, Pennsylvania",Andrew Swan,M,0,24:26.0,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 5km,Yes,"IJA, Reading, Pennsylvania",Jake Immerman,M,0,25:36.0,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 5km,Yes,"IJA, Reading, Pennsylvania",Heather Marriott,F,USA,25:43.0,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 5km,Yes,"IJA, Reading, Pennsylvania",Timmy Boas,M,0,25:57.0,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 5km,Yes,"IJA, Reading, Pennsylvania",Danny Tomaro,M,0,27:35.0,?,https://dev.juggle.org/history/champs/champs2002.php
+17/07/2002,2002,3b 5km,Yes,"IJA, Reading, Pennsylvania",Gil Pontius,M,0,28:44.0,?,https://dev.juggle.org/history/champs/champs2002.php
+06/05/2002,2002,3b Marathon,Yes,"Flying Pig Marathon, Cincinnati",Perry Romanowski,M,USA,25:25.0,?,https://marathonview.net/result/60881124
+07/10/2001,2001,3b Marathon,Yes,Chicago Marathon,Perry Romanowski,M,USA,25:25.0,?,https://chicago-history.r.mikatiming.com/2021/?pid=search
+28/07/2001,2001,3b 60m,Yes,"IJA, Wisconsin",Jamie Whoolery,M,0,00:08.8,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b 60m,Yes,"IJA, Wisconsin",Lana Bolin,F,0,00:10.0,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b 60m,Yes,"IJA, Wisconsin",Andrew Swan,M,0,00:10.0,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b 60m,Yes,"IJA, Wisconsin",Marlin Ballard,M,0,00:10.1,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b 60m,Yes,"IJA, Wisconsin",Sasha Kluger,M,0,00:10.3,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b 60m,Yes,"IJA, Wisconsin",Zach Waickman,M,0,00:10.4,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b 60m,Yes,"IJA, Wisconsin",Kelsey Deutch,F,0,00:10.8,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b 60m,Yes,"IJA, Wisconsin",Heather Marriott,F,USA,00:11.0,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b 60m,Yes,"IJA, Wisconsin",Sandy Brown,F,0,00:11.1,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b 60m,Yes,"IJA, Wisconsin",Mike Draney,M,0,00:11.4,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b 60m,Yes,"IJA, Wisconsin",Nathan Seedfeldt,M,0,00:11.5,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b 60m,Yes,"IJA, Wisconsin",Joe Otonichar,M,0,00:11.5,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,5b 60m,Yes,"IJA, Wisconsin",Ben Schoenberg,M,0,00:11.8,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b 60m,Yes,"IJA, Wisconsin",Jack Hirschowitz,M,USA,00:11.8,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,5b 60m,Yes,"IJA, Wisconsin",Sam Hartford,M,0,00:12.7,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b 60m,Yes,"IJA, Wisconsin",Eric Blaha,M,0,00:12.9,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b 60m,Yes,"IJA, Wisconsin",Vytas Vaitkus,M,0,00:12.9,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b 60m,Yes,"IJA, Wisconsin",Cameron Ridder,M,0,00:13.2,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b 60m,Yes,"IJA, Wisconsin",David Cruz,M,0,00:14.9,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,5b 60m,Yes,"IJA, Wisconsin",Heather Marriott,F,USA,00:15.0,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b 60m,Yes,"IJA, Wisconsin",Pete Finger,M,0,00:15.2,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b 60m,Yes,"IJA, Wisconsin",Jon Poppele,M,0,00:15.4,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,5b 60m,Yes,"IJA, Wisconsin",Nicholas Souren,M,0,00:15.4,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b 60m,Yes,"IJA, Wisconsin",Glen Ritter,M,0,00:15.6,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,5b 60m,Yes,"IJA, Wisconsin",Nathan Seedfeldt,M,0,00:15.7,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b 60m,Yes,"IJA, Wisconsin",Jerry Battenfield,M,0,00:16.7,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b 60m,Yes,"IJA, Wisconsin",J Butler,F,0,00:23.6,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,5b 60m,Yes,"IJA, Wisconsin",Andrew Swan,M,0,00:26.3,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,5b 60m,Yes,"IJA, Wisconsin",Marlin Ballard,M,0,00:28.6,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b 200m,Yes,"IJA, Wisconsin",Zach Waickman,M,0,00:36.8,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,5b 60m,Yes,"IJA, Wisconsin",Jack Hirschowitz,M,USA,00:41.3,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b 200m,Yes,"IJA, Wisconsin",Mike Gracie,M,0,00:46.5,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b 200m,Yes,"IJA, Wisconsin",Eric Blaha,M,0,00:51.7,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b 200m,Yes,"IJA, Wisconsin",Joe Otonichar,M,0,00:51.8,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b 400m,Yes,"IJA, Wisconsin",Jamie Whoolery,M,0,01:04.9,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b 200m,Yes,"IJA, Wisconsin",Amy Barnes,F,0,01:05.0,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b 4x100m,Yes,"IJA, Wisconsin","Marlin Ballard, Mike Draney, Jon Poppele, Ben Schoenberg",#N/A,#N/A,01:08.1,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b 400m,Yes,"IJA, Wisconsin",Sam Hartford,M,0,01:11.1,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b 200m,Yes,"IJA, Wisconsin",J Butler,F,0,01:11.8,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b 400m,Yes,"IJA, Wisconsin",Ben Schoenberg,M,0,01:12.0,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b 400m,Yes,"IJA, Wisconsin",Nathan Seedfeldt,M,0,01:12.2,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b 4x100m,Yes,"IJA, Wisconsin","Sam Hartford, Nicolas Souren, Jamie Whoolery",#N/A,#N/A,01:14.1,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b 400m,Yes,"IJA, Wisconsin",Mike Draney,M,0,01:14.1,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b 400m,Yes,"IJA, Wisconsin",Darin Marriott,M,USA,01:16.0,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b 400m,Yes,"IJA, Wisconsin",Nicholas Souren,M,0,01:16.5,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b 400m,Yes,"IJA, Wisconsin",Andrew Swan,M,0,01:19.3,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b 400m,Yes,"IJA, Wisconsin",Steve Caruso,M,0,01:20.4,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b 4x100m,Yes,"IJA, Wisconsin","Eric Blaha, Joe Otonichar, Vytas Vaitkus, Zach Waickman",#N/A,#N/A,01:20.5,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b 400m,Yes,"IJA, Wisconsin",Vytas Vaitkus,M,0,01:21.6,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b 4x100m,Yes,"IJA, Wisconsin","Lana Bolin, Kelsey Deutsch, Mike Gracie, Valida Prentice",#N/A,#N/A,01:24.6,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b 400m,Yes,"IJA, Wisconsin",Heather Marriott,F,USA,01:25.4,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b 4x100m,Yes,"IJA, Wisconsin","David Cruz, Pete Finger, Darrin Marriott, Glen Ritter",#N/A,#N/A,01:26.3,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b 4x100m,Yes,"IJA, Wisconsin","Tim Baird, Jerry Battenfield, Jack Hirschowitz, Andrew Swan",#N/A,#N/A,01:30.1,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b 400m,Yes,"IJA, Wisconsin",Jack Hirschowitz,M,USA,01:30.6,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b 400m,Yes,"IJA, Wisconsin",Marlin Ballard,M,0,01:41.6,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b 400m,Yes,"IJA, Wisconsin",Sasha Kluger,M,0,01:44.6,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b 400m,Yes,"IJA, Wisconsin",Charles Schweitzer,M,USA,01:57.9,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b 4x100m,Yes,"IJA, Wisconsin","Amy Barnes, Heather Marriott",#N/A,#N/A,01:59.7,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b 4x100m,Yes,"IJA, Wisconsin","Jane Birkhead, Sandy Brown, Kay Caskey, Laurie Young",#N/A,#N/A,02:17.2,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b 400m,Yes,"IJA, Wisconsin",Jonathan Hartford,M,0,02:44.1,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b 400m,Yes,"IJA, Wisconsin",J Butler,F,0,02:55.9,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b 4x400m,Yes,"IJA, Wisconsin","Sam Hartford, Ben Schoenberg, Nicolas Souren, Jamie Whoolery",#N/A,#N/A,05:00.5,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b Mile,Yes,"IJA, Wisconsin",Jamie Whoolery,M,0,05:53.1,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b 4x400m,Yes,"IJA, Wisconsin","Eric Blaha, Joe Otonichar, Vytas Vaitkus, Zach Waickman",#N/A,#N/A,05:55.2,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b 4x400m,Yes,"IJA, Wisconsin","Steve Caruso, Sasha Kluger, Cameron Ritter, Nate Seefeldt",#N/A,#N/A,05:55.3,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b Mile,Yes,"IJA, Wisconsin",Mike Draney,M,0,06:06.2,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b 4x400m,Yes,"IJA, Wisconsin","Pete Finger, Jon Poppele, Glen Ritter",#N/A,#N/A,06:17.0,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b Mile,Yes,"IJA, Wisconsin",Andrew Swan,M,0,06:27.0,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b 4x400m,Yes,"IJA, Wisconsin","Amy Barnes, David Cruz, Mike Draney, Heather Marriott",#N/A,#N/A,06:47.0,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b Mile,Yes,"IJA, Wisconsin",Heather Marriott,F,USA,07:15.2,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b Mile,Yes,"IJA, Wisconsin",Vytas Vaitkus,M,0,07:25.0,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b Mile,Yes,"IJA, Wisconsin",Steve Caruso,M,0,07:25.1,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b Mile,Yes,"IJA, Wisconsin",Glen Ritter,M,0,07:50.0,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b Mile,Yes,"IJA, Wisconsin",Charles Schweitzer,M,USA,08:18.0,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b 4x400m,Yes,"IJA, Wisconsin","Tim Baird, Jerry Battenfield, Jack Hirschowitz, Andy Swan",#N/A,#N/A,08:28.9,?,https://dev.juggle.org/history/champs/champs2001.php
+28/07/2001,2001,3b 4x400m,Yes,"IJA, Wisconsin","Jane Birkhead, Sandy Brown, Kay Caskey, Laurie Young",#N/A,#N/A,10:13.7,?,https://dev.juggle.org/history/champs/champs2001.php
+28/04/2001,2001,3b Marathon,Yes,Nashville Country Music Marathon,Perry Romanowski,M,USA,18:28.0,?,
+22/04/2001,2001,3c Marathon,No,London Marathon,Colin Francome,M,GBR,03:22.0,?,https://www.gazetteandherald.co.uk/news/7366767.serious-stuff-for-colin-the-clown/  https://marathonview.net/search?query=colin%20francome
+22/10/2000,2000,3b Marathon,Yes,Chicago Marathon,Perry Romanowski,M,USA,16:06.0,?,https://chicago-history.r.mikatiming.com/2021/?pid=search
+10/08/2000,2000,3b Marathon,Yes,"Karlsruhe, Germany",Paul-Erik Lillholm,M,NOR,20:49.0,?,
+05/08/2000,2000,3b 100m,Yes,"IJA, Montreal",Albert Lucas,M,USA,00:12.2,?,https://dev.juggle.org/history/champs/champs2000.php
+05/08/2000,2000,3b 100m,Yes,"IJA, Montreal",Travis Saunders,M,CAN,00:13.2,?,https://dev.juggle.org/history/champs/champs2000.php
+05/08/2000,2000,3b 100m,Yes,"IJA, Montreal",Barry Goldmeier,M,USA,00:14.0,?,https://dev.juggle.org/history/champs/champs2000.php
+05/08/2000,2000,3b 100m,Yes,"IJA, Montreal",Nathan Seedfeldt,M,0,00:14.0,?,https://dev.juggle.org/history/champs/champs2000.php
+05/08/2000,2000,3b 100m,Yes,"IJA, Montreal",Hayley Fix,F,0,00:14.5,?,https://dev.juggle.org/history/champs/champs2000.php
+05/08/2000,2000,3b 100m,Yes,"IJA, Montreal",Lana Bolin,F,0,00:15.0,?,https://dev.juggle.org/history/champs/champs2000.php
+05/08/2000,2000,3b 100m,Yes,"IJA, Montreal",Andrew Swan,M,0,00:15.9,?,https://dev.juggle.org/history/champs/champs2000.php
+05/08/2000,2000,3b 100m,Yes,"IJA, Montreal",Andrew Swan,M,0,00:16.0,?,https://dev.juggle.org/history/champs/champs2000.php
+05/08/2000,2000,3b 100m,Yes,"IJA, Montreal",Jack Hirschowitz,M,USA,00:21.1,?,https://dev.juggle.org/history/champs/champs2000.php
+05/08/2000,2000,5b 100m,Yes,"IJA, Montreal",Ben Schoenberg,M,0,00:22.7,?,https://dev.juggle.org/history/champs/champs2000.php
+05/08/2000,2000,5b 100m,Yes,"IJA, Montreal",Nathan Seedfeldt,M,0,00:25.5,?,https://dev.juggle.org/history/champs/champs2000.php
+05/08/2000,2000,3b 100m,Yes,"IJA, Montreal",Jerry Battenfield,M,0,00:25.8,?,https://dev.juggle.org/history/champs/champs2000.php
+05/08/2000,2000,3b 200m,Yes,"IJA, Montreal",Travis Saunders,M,CAN,00:27.4,?,https://dev.juggle.org/history/champs/champs2000.php
+05/08/2000,2000,3b 200m,Yes,"IJA, Montreal",Albert Lucas,M,USA,00:27.7,?,https://dev.juggle.org/history/champs/champs2000.php
+05/08/2000,2000,5b 100m,Yes,"IJA, Montreal",Barry Goldmeier,M,USA,00:29.3,?,https://dev.juggle.org/history/champs/champs2000.php
+05/08/2000,2000,3b 200m,Yes,"IJA, Montreal",Jamie Whoolery,M,0,00:30.7,?,https://dev.juggle.org/history/champs/champs2000.php
+05/08/2000,2000,3b 200m,Yes,"IJA, Montreal",Andrew Swan,M,0,00:32.8,?,https://dev.juggle.org/history/champs/champs2000.php
+05/08/2000,2000,3b 200m,Yes,"IJA, Montreal",Lana Bolin,F,0,00:34.3,?,https://dev.juggle.org/history/champs/champs2000.php
+05/08/2000,2000,3b 200m,Yes,"IJA, Montreal",Jaye Butler,M,0,00:39.0,?,https://dev.juggle.org/history/champs/champs2000.php
+05/08/2000,2000,5b 100m,Yes,"IJA, Montreal",Andrew Swan,M,0,00:46.2,?,https://dev.juggle.org/history/champs/champs2000.php
+05/08/2000,2000,3b 400m,Yes,"IJA, Montreal",Albert Lucas,M,USA,01:00.2,?,https://dev.juggle.org/history/champs/champs2000.php
+05/08/2000,2000,3b 400m,Yes,"IJA, Montreal",Travis Saunders,M,CAN,01:00.5,?,https://dev.juggle.org/history/champs/champs2000.php
+05/08/2000,2000,3b 400m,Yes,"IJA, Montreal",Jamie Whoolery,M,0,01:06.7,?,https://dev.juggle.org/history/champs/champs2000.php
+05/08/2000,2000,3b 400m,Yes,"IJA, Montreal",Joshua Edleman,M,0,01:11.6,?,https://dev.juggle.org/history/champs/champs2000.php
+05/08/2000,2000,3b 400m,Yes,"IJA, Montreal",Mark Cembrowski,M,0,01:14.6,?,https://dev.juggle.org/history/champs/champs2000.php
+05/08/2000,2000,3b 400m,Yes,"IJA, Montreal",Lana Bolin,F,0,01:17.7,?,https://dev.juggle.org/history/champs/champs2000.php
+05/08/2000,2000,3b 400m,Yes,"IJA, Montreal",Andrew Swan,M,0,01:24.2,?,https://dev.juggle.org/history/champs/champs2000.php
+05/08/2000,2000,3b 400m,Yes,"IJA, Montreal",Jack Hirschowitz,M,USA,01:24.8,?,https://dev.juggle.org/history/champs/champs2000.php
+05/08/2000,2000,3b 400m,Yes,"IJA, Montreal",Simon George,M,0,01:38.5,?,https://dev.juggle.org/history/champs/champs2000.php
+05/08/2000,2000,3b 4x400m,Yes,"IJA, Montreal","Barry Goldmeier, Albert Lucas, Ben Schoenberg, John Zaleskie",#N/A,#N/A,04:54.1,?,https://dev.juggle.org/history/champs/champs2000.php
+05/08/2000,2000,3b 4x400m,Yes,"IJA, Montreal","Lana Bolin, Kelsey Deutsch, Hayley Fix, Erika Randall",#N/A,#N/A,05:39.0,?,https://dev.juggle.org/history/champs/champs2000.php
+05/08/2000,2000,3b Mile,Yes,"IJA, Montreal",Jamie Whoolery,M,0,05:58.4,?,https://dev.juggle.org/history/champs/champs2000.php
+05/08/2000,2000,3b Mile,Yes,"IJA, Montreal",Sam Hartford,M,0,06:02.2,?,https://dev.juggle.org/history/champs/champs2000.php
+05/08/2000,2000,3b 4x400m,Yes,"IJA, Montreal","Jerry Battenfield, Jack Hirschowitz, Gil Pontius, Andrew Swan",#N/A,#N/A,06:32.7,?,https://dev.juggle.org/history/champs/champs2000.php
+05/08/2000,2000,3b Mile,Yes,"IJA, Montreal",Gil Pontius,M,0,06:35.2,?,https://dev.juggle.org/history/champs/champs2000.php
+05/08/2000,2000,3b Mile,Yes,"IJA, Montreal",Joshua Edleman,M,0,06:39.0,?,https://dev.juggle.org/history/champs/champs2000.php
+05/08/2000,2000,3b Mile,Yes,"IJA, Montreal",Lana Bolin,F,0,06:49.3,?,https://dev.juggle.org/history/champs/champs2000.php
+05/08/2000,2000,3b Mile,Yes,"IJA, Montreal",Andrew Swan,M,0,06:58.3,?,https://dev.juggle.org/history/champs/champs2000.php
+05/08/2000,2000,3b Mile,Yes,"IJA, Montreal",Simon George,M,0,07:00.0,?,https://dev.juggle.org/history/champs/champs2000.php
+05/08/2000,2000,3b Mile,Yes,"IJA, Montreal",Tim Baird,M,0,07:15.0,?,https://dev.juggle.org/history/champs/champs2000.php
+05/08/2000,2000,3b 5km,Yes,"IJA, Montreal",Andrew Swan,M,0,23:45.6,?,https://dev.juggle.org/history/champs/champs2000.php
+05/08/2000,2000,3b 5km,Yes,"IJA, Montreal",Sam Hartford,M,0,23:46.7,?,https://dev.juggle.org/history/champs/champs2000.php
+05/08/2000,2000,3b 5km,Yes,"IJA, Montreal",Joshua Edleman,M,0,24:35.0,?,https://dev.juggle.org/history/champs/champs2000.php
+24/10/1999,1999,3b Marathon,Yes,Chicago Marathon,Perry Romanowski,M,USA,07:18.0,?,https://chicago-history.r.mikatiming.com/2021/?pid=search
+19/10/1997,1997,3b Marathon,Yes,Chicago Marathon,Perry Romanowski,M,USA,09:49.0,?,https://chicago-history.r.mikatiming.com/2021/?pid=search
+19/10/1997,1997,3b Marathon,Yes,Detroit Free Press Marathon,Riley McLincha,M,USA,21:12.0,30,https://www.athlinks.com/event/154412/results/Event/15106/Course/22290/Entry/10440441
+20/10/1996,1996,3b Marathon,Yes,Chicago Marathon,Perry Romanowski,M,USA,05:41.0,?,https://chicago-history.r.mikatiming.com/2021/?pid=search
+05/12/1991,1991,3b Marathon,Yes,California International Marathon,Bill Coad,M,USA,43:38.0,?,https://www.justyouraveragejoggler.com/bill-coad-entertainer-business-owner-and-joggler/  https://marathonview.net/search?query=william%20coad
+05/03/1989,1989,3b Marathon,Yes,Los Angeles Marathon,Mike Hebebrand,M,USA,32:00.0,10,https://www.latimes.com/archives/la-xpm-1989-04-24-me-1750-story.html
+06/11/1988,1988,5b Marathon,Yes,New York City Marathon,Billy Gillen,M,USA,07:16.0,?,"https://results.nyrr.org/event/881106/finishers/1329691#search=William%2520Gillen     https://www.dev.juggle.org/history/archives/jugmags/41-3/41-3,p6.htm"
+04/07/1988,1988,3b Marathon,Yes,Salmon River Idaho,Ashrita Furman,M,USA,22:32.0,?,
+01/11/1987,1987,3b Marathon,Yes,New York Marathon,Albert Lucas,M,USA,58:43.0,?,His second joggling marathon. http://www.juggling.org/jw/87/4/notes.html
+01/03/1987,1987,3b Marathon,Yes,Los Angeles Marathon,Albert Lucas,M,USA,04:35.0,0,Albert's first joggling marathon. https://www.instagram.com/p/B9awUjCHeG-/ Also documented in Jugglers World Spring 1987 Newsletter
+30/05/1982,1982,3b Marathon,Yes,Montreal International Marathon,Michel Lauzière,M,CAN,57:00.0,?,Email exchange
+12/09/1981,1981,3b Marathon,Yes,Montreal International Marathon,Michel Lauzière,M,CAN,05:00.0,1,"The very first marathon joggled http://www.dev.juggle.org/history/archives/jugmags/33-5/33-5,p28.htm  https://michellauziere.com/en/biography?fbclid=IwAR2anhLNF-oEFjURGW7YdlZSqmlNxilYRQdh3MeirIdGkLK9dzQRfV8nOwM"
+16/07/1981,1981,3b 100m,Yes,"IJA, Cleveland, Ohio",Paul Williams,M,0,00:14.5,?,https://dev.juggle.org/history/champs/champs1981.php
+16/07/1981,1981,3b 100m,Yes,"IJA, Cleveland, Ohio",Bill Giduz,M,USA,00:14.9,?,https://dev.juggle.org/history/champs/champs1981.php
+16/07/1981,1981,3b 100m,Yes,"IJA, Cleveland, Ohio",Michel Lauzière,M,CAN,00:15.1,?,https://dev.juggle.org/history/champs/champs1981.php
+16/07/1981,1981,3b 1500m,Yes,"IJA, Cleveland, Ohio",Michel Lauzière,M,CAN,05:03.0,?,"Email exchange inc photo of newpaper article, http://www.juggling.org/orgs/ija/champs.txt"
+16/07/1981,1981,3b 1500m,Yes,"IJA, Cleveland, Ohio",Bill Giduz,M,USA,05:26.0,?,https://dev.juggle.org/history/champs/champs1981.php
+16/07/1981,1981,3b 1500m,Yes,"IJA, Cleveland, Ohio",Gerry Berg,M,0,05:36.0,?,https://dev.juggle.org/history/champs/champs1981.php
+16/07/1981,1981,3b 5km,Yes,"IJA, Cleveland, Ohio",Paul Williams,M,0,20:11.0,?,https://dev.juggle.org/history/champs/champs1981.php
+16/07/1981,1981,3b 5km,Yes,"IJA, Cleveland, Ohio",Larry Kluger,M,0,21:09.0,?,https://dev.juggle.org/history/champs/champs1981.php
+16/07/1981,1981,3b 5km,Yes,"IJA, Cleveland, Ohio",Dan Berg,M,0,21:34.0,?,https://dev.juggle.org/history/champs/champs1981.php
 10/11/1979,1979,3b 10km,Yes,"Vulcan Run, Birmingham, USA",Bill Giduz,M,USA,??,?,https://championship-racing.com/results/history/VULCAN%20RUN%20History.pdf
-2023,2023,3b 5km,Yes,"IJA, Virtual",Daniel Raum,M,AUT,00:20:18.00,?,https://www.facebook.com/groups/372157942956062
-2023,2023,3b 5km,Yes,"IJA, Virtual",Brady Xue,M,USA,00:20:25.00,?,https://www.facebook.com/groups/372157942956062
-2023,2023,3b 5km,Yes,"IJA, Virtual",Christoph Mitasch,M,0,00:21:06.00,?,https://www.facebook.com/groups/372157942956062
-2023,2023,3b 5km,Yes,"IJA, Virtual",Sterling Franklin,M,USA,00:21:57.00,?,https://www.facebook.com/groups/372157942956062
-2023,2023,3b 5km,Yes,"IJA, Virtual",JoAnn Ireland,F,USA,00:39:23.00,?,https://www.facebook.com/groups/372157942956062
-2022,2022,3b 5km,Yes,"IJA, Virtual",Daniel Raum,M,AUT,00:19:58.00,?,https://www.juggle.org/enewsletter/2022-08
-2022,2022,3b 10km,Yes,Time Trial,Chris Edwin,M,GBR,00:36:02.00,0,
-2020,2020,3b Mile,Yes,"IJA, Virtual",Sterling Franklin,M,USA,00:05:29.00,?,https://www.juggle.org/festival-details/online-joggling-championships/
-2020,2020,3b Mile,Yes,"IJA, Virtual",Craig Muhlenkamp,M,USA,00:06:54.00,?,https://www.juggle.org/festival-details/online-joggling-championships/
-2020,2020,3b Mile,Yes,"IJA, Virtual",Marla Edgecomb,F,USA,00:10:45.00,?,https://www.juggle.org/festival-details/online-joggling-championships/
-2020,2020,3b 5km,Yes,"IJA, Virtual",Michael-Lucien Bergeron,M,CAN,00:16:49.00,0,https://www.juggle.org/festival-details/online-joggling-championships/
-2020,2020,3b 5km,Yes,"IJA, Virtual",Sterling Franklin,M,USA,00:19:43.00,?,https://www.juggle.org/festival-details/online-joggling-championships/
-2020,2020,3b 5km,Yes,"IJA, Virtual",Christoph Mitasch,M,0,00:23:34.00,?,https://www.juggle.org/festival-details/online-joggling-championships/
-2020,2020,3b 5km,Yes,"IJA, Virtual",Koutaro Kawano,M,JPN,00:24:07.00,?,https://www.juggle.org/festival-details/online-joggling-championships/
-2020,2020,3b 5km,Yes,"IJA, Virtual",Craig Muhlenkamp,M,USA,00:26:17.00,?,https://www.juggle.org/festival-details/online-joggling-championships/
-2020,2020,3b Marathon,Yes,New York Virtual Marathon,Barak Hirschowitz,M,USA,04:37:21.00,?,https://results.nyrr.org/event/20VMara/finishers#search=Barak%2520Hirschowitz
-2019,2019,3b 5km,Yes,Guelph 5km,Gabrielle Foran,F,CAN,00:20:42.00,?,https://sites.google.com/site/guelph5kjoggling/results
-2019,2019,3b 5km,Yes,Guelph 5km,Greg Philips,M,0,00:27:19.00,?,https://sites.google.com/site/guelph5kjoggling/results
-2019,2019,3b 5km,Yes,Guelph 5km,Mark Jolin,M,0,00:36:02.00,?,https://sites.google.com/site/guelph5kjoggling/results
-2019,2019,3b 17km,No,Wings for Life World Run,Levent Denizci,M,TUR,01:39:00.00,1,
-2019,2019,3b Half Marathon,Yes,Eskisehir Half Marathon,Levent Denizci,M,TUR,02:09:18.00,3,
-2019,2019,3b Half Marathon,Yes,Istanbul Half Marathon,Levent Denizci,M,TUR,02:10:05.00,2,
-2018,2018,3b 5km,Yes,Guelph 5km,Michal Kapral,M,CAN,00:19:05.00,?,https://sites.google.com/site/guelph5kjoggling/results
-2018,2018,3b 5km,Yes,Guelph 5km,Gabrielle Foran,F,CAN,00:19:09.00,?,https://sites.google.com/site/guelph5kjoggling/results
-2018,2018,3b 5km,Yes,Guelph 5km,Sydney McDonald,M,0,00:21:39.00,?,https://sites.google.com/site/guelph5kjoggling/results
-2018,2018,3b 5km,Yes,Guelph 5km,Morgan Anderson,F,0,00:24:42.00,?,https://sites.google.com/site/guelph5kjoggling/results
-2018,2018,3b 5km,Yes,Guelph 5km,Greg Philips,M,0,00:25:05.00,?,https://sites.google.com/site/guelph5kjoggling/results
-2018,2018,3b 5km,Yes,Guelph 5km,Ely Doan,M,0,00:26:05.00,?,https://sites.google.com/site/guelph5kjoggling/results
-2018,2018,3b 5km,Yes,Guelph 5km,Mike Moore,M,USA,00:26:20.00,?,https://sites.google.com/site/guelph5kjoggling/results
-2018,2018,3b 5km,Yes,Guelph 5km,David Pavlove Cunsolo,M,0,00:30:17.00,?,https://sites.google.com/site/guelph5kjoggling/results
-2018,2018,3b 15km,No,Istanbul,Levent Denizci,M,TUR,01:35:30.00,8,
-2018,2018,3b Half Marathon,Yes,Giresun Half Marathon,Levent Denizci,M,TUR,01:56:38.00,3,
-2018,2018,3b Half Marathon,Yes,Istanbul Half Marathon,Levent Denizci,M,TUR,01:59:31.00,4,
-2018,2018,3b Half Marathon,Yes,Edirne Half Marathon,Levent Denizci,M,TUR,02:17:35.00,9,
-2017,2017,3b 5km,Yes,Guelph 5km,Gabrielle Foran,F,CAN,00:19:12.00,?,https://sites.google.com/site/guelph5kjoggling/results
-2017,2017,3b 5km,Yes,"IJA, Lisbon, IA",Jacob Heimer,M,0,00:19:16.00,?,https://www.juggle.org/enewsletter/2017-07
-2017,2017,3b 5km,Yes,"IJA, Lisbon, IA",Gabrielle Foran,F,CAN,00:19:29.00,?,https://www.juggle.org/enewsletter/2017-07
-2017,2017,3b 5km,Yes,"IJA, Lisbon, IA",Bob Evans,M,USA,00:19:36.00,?,https://www.juggle.org/enewsletter/2017-07
-2017,2017,3b 5km,Yes,"IJA, Lisbon, IA",Erik Rain,M,0,00:20:26.00,?,https://www.juggle.org/enewsletter/2017-07
-2017,2017,3b 5km,Yes,"IJA, Lisbon, IA",Paul Arneberg,M,0,00:22:37.00,?,https://www.juggle.org/enewsletter/2017-07
-2017,2017,3b 5km,Yes,Guelph 5km,Julian Tam,M,0,00:23:49.00,?,https://sites.google.com/site/guelph5kjoggling/results
-2017,2017,3b 5km,Yes,"IJA, Lisbon, IA",Shahar Cohen,M,ISR,00:24:00.00,?,https://www.juggle.org/enewsletter/2017-07
-2017,2017,3b 5km,Yes,"IJA, Lisbon, IA",Katie Burgess,F,0,00:24:37.00,?,https://www.juggle.org/enewsletter/2017-07
-2017,2017,3b 5km,Yes,Guelph 5km,Boris Georgiev,M,0,00:24:42.00,?,https://sites.google.com/site/guelph5kjoggling/results
-2017,2017,3b 5km,Yes,"IJA, Lisbon, IA",Tony Malikowski,M,USA,00:24:42.00,?,https://www.juggle.org/enewsletter/2017-07
-2017,2017,3b 5km,Yes,"IJA, Lisbon, IA",Craig Wise,M,0,00:24:48.00,?,https://www.juggle.org/enewsletter/2017-07
-2017,2017,3b 5km,Yes,Guelph 5km,Tony Malikowski,M,USA,00:25:08.00,?,https://sites.google.com/site/guelph5kjoggling/results
-2017,2017,3b 5km,Yes,"IJA, Lisbon, IA",Jason Noye,M,0,00:26:15.00,?,https://www.juggle.org/enewsletter/2017-07
-2017,2017,3b 5km,Yes,"IJA, Lisbon, IA",Mike Moore,M,USA,00:27:11.00,?,https://www.juggle.org/enewsletter/2017-07
-2017,2017,3b 5km,Yes,"IJA, Lisbon, IA",Jared Ashton,M,0,00:27:51.00,?,https://www.juggle.org/enewsletter/2017-07
-2017,2017,3b 5km,Yes,"IJA, Lisbon, IA",Nathan Wakefield,M,0,00:27:56.00,?,https://www.juggle.org/enewsletter/2017-07
-2017,2017,3b 5km,Yes,"IJA, Lisbon, IA",Jack Hirschowitz,M,USA,00:28:21.00,?,https://www.juggle.org/enewsletter/2017-07
-2017,2017,3b 5km,Yes,Guelph 5km,Ely Doan,M,0,00:28:26.00,?,https://sites.google.com/site/guelph5kjoggling/results
-2017,2017,3b 5km,Yes,Guelph 5km,Gavin Hossack,M,0,00:30:07.00,?,https://sites.google.com/site/guelph5kjoggling/results
-2017,2017,3b 5km,Yes,"IJA, Lisbon, IA",Carter Randall,M,0,00:30:19.00,?,https://www.juggle.org/enewsletter/2017-07
-2017,2017,3b 5km,Yes,"IJA, Lisbon, IA",David Pavlove Cunsolo,M,0,00:30:22.00,?,https://www.juggle.org/enewsletter/2017-07
-2017,2017,3b 5km,Yes,"IJA, Lisbon, IA",Mary Geeves,F,0,00:32:10.00,?,https://www.juggle.org/enewsletter/2017-07
-2017,2017,3b 5km,Yes,Guelph 5km,David Pavlove Cunsolo,M,0,00:33:15.00,?,https://sites.google.com/site/guelph5kjoggling/results
-2017,2017,3b 5km,Yes,Guelph 5km,Eric Malikowski,M,0,00:34:45.00,?,https://sites.google.com/site/guelph5kjoggling/results
-2017,2017,3b 5km,Yes,"IJA, Lisbon, IA",Sarah Williams,F,0,00:45:37.00,?,https://www.juggle.org/enewsletter/2017-07
-2017,2017,3b 5km,Yes,"IJA, Lisbon, IA",Scott Randall,M,0,00:47:53.00,?,https://www.juggle.org/enewsletter/2017-07
-2017,2017,3c 10km,Yes,Ignite Istanbul,Levent Denizci,M,TUR,01:05:37.00,10,
-2017,2017,3b 15km,No,Istanbul,Ferda Tekgül,M,TUR,01:35:55.00,?,https://event.spor.istanbul/eventresults.aspx
-2017,2017,3c 15km,No,Istanbul,Levent Denizci,M,TUR,01:47:42.00,10,
-2016,2016,3b 5km,Yes,Guelph 5km,Gabrielle Foran,F,CAN,00:18:26.00,?,https://sites.google.com/site/guelph5kjoggling/results
-2016,2016,3b 5km,Yes,Guelph 5km,Julian Tam,M,0,00:23:22.00,?,https://sites.google.com/site/guelph5kjoggling/results
-2016,2016,3b 5km,Yes,Guelph 5km,Mike Moore,M,USA,00:23:56.00,?,https://sites.google.com/site/guelph5kjoggling/results
-2016,2016,3b 5km,Yes,Guelph 5km,Ely Doan,M,0,00:25:00.00,?,https://sites.google.com/site/guelph5kjoggling/results
-2016,2016,3b 5km,Yes,Guelph 5km,Boris Georgiev,M,0,00:29:45.00,?,https://sites.google.com/site/guelph5kjoggling/results
-2016,2016,3b 5km,Yes,Guelph 5km,David Pavlove Cunsolo,M,0,00:42:23.00,?,https://sites.google.com/site/guelph5kjoggling/results
-2016,2016,3b 10km,Yes,Ignite Istanbul,Levent Denizci,M,TUR,00:54:42.00,2,Levent shared a pdf doc of his results
-2016,2016,3b 13km,No,Wings for Life World Run,Levent Denizci,M,TUR,01:24:08.00,4,
-2016,2016,3b 15km,No,Istanbul,Levent Denizci,M,TUR,01:24:35.00,0,Levent shared a pdf doc of his results
-2015,2015,3b 26km,No,Istanbul,Levent Denizci,M,TUR,02:37:41.00,4,Levent shared a pdf doc of his results
-2014,2014,3b Half Marathon,Yes,Istanbul Half Marathon,Levent Denizci,M,TUR,02:01:19.00,3,https://www.instagram.com/p/BIl1YIKDEa0/
-2014,2014,3b Half Marathon,Yes,Runtalya,Levent Denizci,M,TUR,02:13:00.00,4,https://www.instagram.com/p/BIjUzCajyuf/
-2013,2013,3b 15km,No,Istanbul,Levent Denizci,M,TUR,01:12:49.00,7,Levent shared a pdf doc of his results
-2013,2013,3b 10km,Yes,Runtalya,Levent Denizci,M,TUR,01:14:27.00,12,https://www.instagram.com/p/BIg06QODG3d/
-2010,2010,3b 5km,Yes,"IJA, Nevada",Tyler Wishau,M,USA,00:19:41.00,?,https://dev.juggle.org/history/champs/champs2010.php
-2010,2010,3b 5km,Yes,"IJA, Nevada",Chris Garcia,M,0,00:23:52.00,?,https://dev.juggle.org/history/champs/champs2010.php
-2010,2010,3b 5km,Yes,"IJA, Nevada",Andrew Swan,M,0,00:27:23.00,?,https://dev.juggle.org/history/champs/champs2010.php
-2010,2010,3b 5km,Yes,"IJA, Nevada",Jack Hirschowitz,M,USA,00:27:33.00,?,https://dev.juggle.org/history/champs/champs2010.php
-2010,2010,3b 5km,Yes,"IJA, Nevada",Dean Bennett,M,0,00:27:40.00,?,https://dev.juggle.org/history/champs/champs2010.php
-2010,2010,3b 5km,Yes,"IJA, Nevada",Andrew Hodge,M,0,00:29:01.00,?,https://dev.juggle.org/history/champs/champs2010.php
-2010,2010,3b 5km,Yes,"IJA, Nevada",Gordon Cornell,M,0,00:37:43.00,?,https://dev.juggle.org/history/champs/champs2010.php
-2008,2008,3b 10km,Yes,"Ukrops Monument Avenue 10k (Richmond, VA)",Jesse Joyner,M,USA,01:00:29.00,?,https://www.trackshackresults.com/richmond/results/2008/10k_results.php?Link=46&Type=3&LName=Joyner&FName=Jesse&City=&State=&Country=
-2008,2008,3b Half Marathon,Yes,"McDonalds Half Marathon (Richmond, VA)",Jesse Joyner,M,USA,02:34:05.00,?,https://www.trackshackresults.com/richmond/results/2008/hm_results.php?Link=22&Type=3&LName=Joyner&FName=Jesse&City=&State=&Country=
-2007,2007,3b 5km,Yes,Time Trial,Tyler Wishau,M,USA,00:17:08.00,0,https://thejoggler.blogspot.com/2007/12/best-joggles-of-2007.html
-2007,2007,3b Marathon,Yes,Tampa Bay Marathon,Perry Romanowski,M,USA,03:23:00.00,?,
-2005,2005,3b 5km,Yes,Berlin,Perry Romanowski,M,USA,00:19:48.00,?,
-1998,1998,3b 5km,Yes,EJC,Mike Hebebrand,M,USA,00:19:00.00,?,From Email exchange with Mike (April 2023)
-1997,1997,3b Mile,Yes,"IJA, Pittsburgh",Reese Edwards,M,0,00:05:13.00,?,https://dev.juggle.org/history/champs/champs1997.php
-1997,1997,3b Mile,Yes,"IJA, Pittsburgh",Mark Kolbus,M,0,00:05:48.00,?,https://dev.juggle.org/history/champs/champs1997.php
-1997,1997,3b Mile,Yes,"IJA, Pittsburgh",Curt Hoffman,M,0,00:06:03.00,?,https://dev.juggle.org/history/champs/champs1997.php
-1997,1997,3b Mile,Yes,"IJA, Pittsburgh",Mickey Campaniello,M,0,00:06:13.00,?,https://dev.juggle.org/history/champs/champs1997.php
-1997,1997,3b Mile,Yes,"IJA, Pittsburgh",Heather Marriott,F,USA,00:06:47.00,?,https://dev.juggle.org/history/champs/champs1997.php
-1997,1997,3b Mile,Yes,"IJA, Pittsburgh",Charles Williams,M,0,00:07:10.00,?,https://dev.juggle.org/history/champs/champs1997.php
-1997,1997,3b Mile,Yes,"IJA, Pittsburgh",Tim Baird,M,0,00:07:15.00,?,https://dev.juggle.org/history/champs/champs1997.php
-1997,1997,3b Mile,Yes,"IJA, Pittsburgh",David Groth,M,0,00:07:35.00,?,https://dev.juggle.org/history/champs/champs1997.php
-1997,1997,3b Mile,Yes,"IJA, Pittsburgh",Marion Caldwell,F,0,00:07:35.00,?,https://dev.juggle.org/history/champs/champs1997.php
-1997,1997,3b Mile,Yes,"IJA, Pittsburgh",Becky Provance,F,0,00:09:10.00,?,https://dev.juggle.org/history/champs/champs1997.php
-1997,1997,3b Mile,Yes,"IJA, Pittsburgh",Laura Provance,F,0,00:09:10.00,?,https://dev.juggle.org/history/champs/champs1997.php
-1997,1997,3b Mile,Yes,"IJA, Pittsburgh",Laurie Young,F,0,00:09:31.00,?,https://dev.juggle.org/history/champs/champs1997.php
-1997,1997,3b 5km,Yes,"IJA, Pittsburgh",Reese Edwards,M,0,00:18:21.00,?,https://dev.juggle.org/history/champs/champs1997.php
-1997,1997,3b 5km,Yes,"IJA, Pittsburgh",Darin Marriott,M,USA,00:18:43.00,?,https://dev.juggle.org/history/champs/champs1997.php
-1997,1997,3b 5km,Yes,"IJA, Pittsburgh",Mark Kolbus,M,0,00:20:50.00,?,https://dev.juggle.org/history/champs/champs1997.php
-1997,1997,3b 5km,Yes,"IJA, Pittsburgh",Mickey Campaniello,M,0,00:21:37.00,?,https://dev.juggle.org/history/champs/champs1997.php
-1997,1997,3b 5km,Yes,"IJA, Pittsburgh",Jerry Kurtz,M,0,00:22:29.00,?,https://dev.juggle.org/history/champs/champs1997.php
-1997,1997,3b 5km,Yes,"IJA, Pittsburgh",George Faust,M,0,00:23:14.00,?,https://dev.juggle.org/history/champs/champs1997.php
-1997,1997,3b 5km,Yes,"IJA, Pittsburgh",Heather Marriott,F,USA,00:23:45.00,?,https://dev.juggle.org/history/champs/champs1997.php
-1997,1997,3b 5km,Yes,"IJA, Pittsburgh",Kay Caskey,F,0,00:26:57.00,?,https://dev.juggle.org/history/champs/champs1997.php
-1997,1997,3b 5km,Yes,"IJA, Pittsburgh",Marion Caldwell,F,0,00:26:57.00,?,https://dev.juggle.org/history/champs/champs1997.php
-1997,1997,3b 5km,Yes,"IJA, Pittsburgh",Scott Anthony,M,0,00:27:22.00,?,https://dev.juggle.org/history/champs/champs1997.php
-1997,1997,3b 5km,Yes,"IJA, Pittsburgh",Natalie McIntyre,F,0,00:28:48.00,?,https://dev.juggle.org/history/champs/champs1997.php
-1996,1996,3b Mile,Yes,"IJA, Rapid City",Albert Lucas,M,USA,00:05:27.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1996,1996,3b Mile,Yes,"IJA, Rapid City",Paul Arneberg,M,0,00:05:39.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1996,1996,3b Mile,Yes,"IJA, Rapid City",Reese Edwards,M,0,00:05:46.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1996,1996,3b Mile,Yes,"IJA, Rapid City",Keith Baker,M,0,00:06:05.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1996,1996,3b Mile,Yes,"IJA, Rapid City",Adam Griffin,M,0,00:06:07.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1996,1996,3b Mile,Yes,"IJA, Rapid City",Marion Caldwell,F,0,00:10:07.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1996,1996,3b Mile,Yes,"IJA, Rapid City",Kay Caskey,F,0,00:10:12.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1996,1996,5b Mile,Yes,"IJA, Rapid City",Ben Schoenberg,M,0,00:10:36.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1996,1996,5b Mile,Yes,"IJA, Rapid City",Barry Goldmeier,M,USA,00:10:37.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1996,1996,3b 5km,Yes,"IJA, Rapid City",Reese Edwards,M,0,00:20:17.00,?,
-1996,1996,3b 5km,Yes,"IJA, Rapid City",Keith Baker,M,0,00:21:38.00,?,
-1996,1996,3b 5km,Yes,"IJA, Rapid City",Andrew Swan,M,0,00:23:21.00,?,
-1996,1996,3b 5km,Yes,"IJA, Rapid City",Ben Schoenberg,M,0,00:24:38.00,?,
-1996,1996,5b 5km,Yes,"IJA, Rapid City",Barry Goldmeier,M,USA,00:27:53.00,?,
-1996,1996,3b 5km,Yes,"IJA, Rapid City",Bill Coad,M,USA,00:29:56.00,?,
-1996,1996,3b 5km,Yes,"IJA, Rapid City",Laurie Young,F,0,00:34:02.00,?,
-1995,1995,3b Mile,Yes,"IJA, Las Vegas",Mike Hebebrand,M,USA,00:05:42.00,?,https://dev.juggle.org/history/champs/champs1995.php
-1995,1995,3b Mile,Yes,"IJA, Las Vegas",Keith Baker,M,0,00:06:01.00,?,https://dev.juggle.org/history/champs/champs1995.php
-1995,1995,3b Mile,Yes,"IJA, Las Vegas",Reese Edwards,M,0,00:06:11.00,?,https://dev.juggle.org/history/champs/champs1995.php
-1995,1995,3b Mile,Yes,"IJA, Las Vegas",Becky Provance,F,0,00:08:57.00,?,https://dev.juggle.org/history/champs/champs1995.php
-1995,1995,3b Mile,Yes,"IJA, Las Vegas",Laurie Young,F,0,00:09:22.00,?,https://dev.juggle.org/history/champs/champs1995.php
-1995,1995,3b 5km,Yes,"IJA, Las Vegas",Mike Hebebrand,M,USA,00:19:54.00,?,https://dev.juggle.org/history/champs/champs1995.php
-1995,1995,3b 5km,Yes,"IJA, Las Vegas",Sam Wildofsky,M,0,00:20:37.00,?,https://dev.juggle.org/history/champs/champs1995.php
-1995,1995,3b 5km,Yes,"IJA, Las Vegas",Reese Edwards,M,0,00:22:37.00,?,https://dev.juggle.org/history/champs/champs1995.php
-1995,1995,5b 5km,Yes,"IJA, Las Vegas",Barry Goldmeier,M,USA,00:33:03.00,?,https://dev.juggle.org/history/champs/champs1995.php
-1995,1995,3b 5km,Yes,"IJA, Las Vegas",Kay Caskey,F,0,00:36:14.00,?,https://dev.juggle.org/history/champs/champs1995.php
-1994,1994,3b Mile,Yes,"IJA, Vermont",Albert Lucas,M,USA,00:05:48.00,?,https://dev.juggle.org/history/champs/champs1994.php
-1994,1994,3b Mile,Yes,"IJA, Vermont",Keith Baker,M,0,00:05:56.00,?,https://dev.juggle.org/history/champs/champs1994.php
-1994,1994,3b Mile,Yes,"IJA, Vermont",Joe Lyons,M,0,00:06:57.00,?,https://dev.juggle.org/history/champs/champs1994.php
-1994,1994,3b Mile,Yes,"IJA, Vermont",Bob Neuman,M,0,00:08:27.00,?,https://dev.juggle.org/history/champs/champs1994.php
-1994,1994,3b Mile,Yes,"IJA, Vermont",Chuck Worrell,M,0,00:09:10.00,?,https://dev.juggle.org/history/champs/champs1994.php
-1994,1994,3b 5km,Yes,"IJA, Vermont, Billy Gillen Memorial 5km",Albert Lucas,M,USA,00:20:50.00,?,https://dev.juggle.org/history/champs/champs1994.php
-1994,1994,3b 5km,Yes,"IJA, Vermont, Billy Gillen Memorial 5km",Keith Baker,M,0,00:21:03.00,?,https://dev.juggle.org/history/champs/champs1994.php
-1994,1994,3b 5km,Yes,"IJA, Vermont, Billy Gillen Memorial 5km",Darren Samson,M,0,00:22:30.00,?,https://dev.juggle.org/history/champs/champs1994.php
-1994,1994,3b 5km,Yes,"IJA, Vermont, Billy Gillen Memorial 5km",Laurie Young,F,0,00:33:13.00,?,https://dev.juggle.org/history/champs/champs1994.php
-1993,1993,3b Mile,Yes,"IJA, Fargo",Mark Kolbus,M,0,00:05:46.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1993,1993,3b Mile,Yes,"IJA, Fargo",Troy Fitzgerald,M,0,00:06:07.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1993,1993,3b Mile,Yes,"IJA, Fargo",Jim Shellard,M,0,00:06:25.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1993,1993,3b Mile,Yes,"IJA, Fargo",Kathy Glynn,F,0,00:07:57.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1993,1993,3b Mile,Yes,"IJA, Fargo",Laurie Young,F,0,00:09:33.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1993,1993,3b Mile,Yes,"IJA, Fargo",Carol Mills,F,0,00:11:15.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1993,1993,3b 5km,Yes,"IJA, Fargo",Mike Hebebrand,M,USA,00:18:35.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1993,1993,3b 5km,Yes,"IJA, Fargo",Jay Pittman ,M,0,00:22:34.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1993,1993,3b 5km,Yes,"IJA, Fargo",Ben Schoenberg,M,0,00:22:35.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1993,1993,3b 5km,Yes,"IJA, Fargo",Bill Coad,M,USA,00:24:36.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1993,1993,3b 5km,Yes,"IJA, Fargo",Kay Caskey,F,0,00:29:31.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1992,1992,3b Mile,Yes,"IJA, Quebec",Troy Fitzgerald,M,0,00:05:30.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1992,1992,3b Mile,Yes,"IJA, Quebec",Robin Chestnut,M,0,00:05:54.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1992,1992,3b Mile,Yes,"IJA, Quebec",Joe Lyons,M,0,00:06:13.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1992,1992,3b Mile,Yes,"IJA, Quebec",Kay Caskey,F,0,00:08:45.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1992,1992,3b Mile,Yes,"IJA, Quebec",Andrea Goranson,F,0,00:10:56.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1992,1992,3b 5km,Yes,"IJA, Quebec",Ben Schoenberg,M,0,00:19:48.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1992,1992,3b 5km,Yes,"IJA, Quebec",Troy Fitzgerald,M,0,00:20:00.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1992,1992,3b 5km,Yes,"IJA, Quebec",Sam Wildofsky,M,0,00:20:25.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1992,1992,3b 5km,Yes,"IJA, Quebec",Laurie Young,F,0,00:27:42.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1992,1992,3b 5km,Yes,"IJA, Quebec",Roni Lynn,F,0,00:32:48.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1991,1991,3b 5km,Yes,"IJA, St. Louis",John Kilgust,M,0,00:20:41.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1991,1991,3b 5km,Yes,"IJA, St. Louis",Billy Gillen,M,USA,00:21:49.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1991,1991,3b 5km,Yes,"IJA, St. Louis",Joe Lyons,M,0,00:22:09.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1991,1991,3b 5km,Yes,"IJA, St. Louis",Steve Otteson,M,0,00:22:36.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1991,1991,3b 5km,Yes,"IJA, St. Louis",Kay Caskey,F,0,00:30:13.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1990,1990,3b Mile,Yes,"IJA, LA",Mike Hebebrand,M,USA,00:05:16.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1990,1990,3b Mile,Yes,"IJA, LA",Mark Branner,M,0,00:05:38.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1990,1990,3b Mile,Yes,"IJA, LA",Christa Rypins,F,0,00:06:43.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1990,1990,3b Mile,Yes,"IJA, LA",Kathy Glynn,F,0,00:07:34.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1990,1990,3b Mile,Yes,"IJA, LA",Kay Caskey,F,0,00:08:44.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1990,1990,3b 5km,Yes,"IJA, LA",Mike Hebebrand,M,USA,00:17:37.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1990,1990,3b 5km,Yes,"IJA, LA",Robert Slick,M,0,00:17:55.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1990,1990,3b 5km,Yes,"IJA, LA",John Kilgust,M,0,00:20:08.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1990,1990,3b 5km,Yes,"IJA, LA",Laurie Young,F,0,00:29:15.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1990,1990,3b 10km,Yes,Time Trial,Mike Hebebrand,M,USA,00:35:45.00,?,From Email exchange with Mike (April 2023)
-1989,1989,3b Mile,Yes,"IJA, Baltimore",Steve Otteson,M,0,00:05:41.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1989,1989,3b Mile,Yes,"IJA, Baltimore",Bill Giduz,M,USA,00:05:47.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1989,1989,3b Mile,Yes,"IJA, Baltimore",Mike Thomasen,M,0,00:05:51.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1989,1989,3b Mile,Yes,"IJA, Baltimore",Kathy Glynn,F,0,00:06:17.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1989,1989,5b Mile,Yes,Time Trial,Billy Gillen,M,USA,00:07:41.00,?,"https://www.dev.juggle.org/history/archives/jugmags/45-2/45-2,p11.htm"
-1989,1989,3b 5km,Yes,"IJA, Baltimore",John Kilgust,M,0,00:19:06.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1989,1989,3b 5km,Yes,"IJA, Baltimore",Steve Otteson,M,0,00:20:33.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1989,1989,3b 5km,Yes,"IJA, Baltimore",Paul Ballard,M,0,00:20:50.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1989,1989,3b 5km,Yes,"IJA, Baltimore",Kay Caskey,F,0,00:27:57.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1989,1989,5b 5km,Yes,Time Trial,Billy Gillen,M,USA,00:28:11.00,?,"https://www.dev.juggle.org/history/archives/jugmags/45-2/45-2,p11.htm"
-1988,1988,3b Mile,Yes,"IJA, Denver",Albert Lucas,M,USA,00:05:35.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1988,1988,3b Mile,Yes,"IJA, Denver",Steve Wilson,M,0,00:05:39.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1988,1988,3b Mile,Yes,"IJA, Denver",John Ellwanger,M,0,00:05:51.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1988,1988,3b Mile,Yes,"IJA, Denver",Tina Fraser,F,0,00:09:40.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1988,1988,3b Mile,Yes,"IJA, Denver",Sarah Breckenridge,F,0,00:10:03.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1988,1988,3b Mile,Yes,"IJA, Denver",Kay Caskey,F,0,00:10:40.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1988,1988,3b 5km,Yes,"IJA, Denver",John Kilgust,M,0,00:19:34.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1988,1988,3b 5km,Yes,"IJA, Denver",Albert Lucas,M,USA,00:20:39.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1988,1988,3b 5km,Yes,"IJA, Denver",Eric Promislow,M,0,00:23:21.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1988,1988,3b 5km,Yes,"IJA, Denver",Laurie Young,F,0,00:30:22.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1988,1988,3b Marathon,Yes,??,Albert Lucas,M,USA,03:29:04.00,?,
-1988,1988,3b Marathon,Yes,West Australian Marathon,Reg Bolton,M,GBR,03:45:50.00,?,https://www.heraldscotland.com/default_content/12429364.reg-bolton/  https://www.jugglingballs.com.au/15-famous-jugglers-from-australia-and-the-world/
-1987,1987,3b Mile,Yes,"IJA, Akron",Todd McLeish,M,0,00:05:26.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1987,1987,3b Mile,Yes,"IJA, Akron",Billy Gillen,M,USA,00:05:28.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1987,1987,3b Mile,Yes,"IJA, Akron",Clarke McFarlane,M,0,00:05:34.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1987,1987,3b 5km,Yes,"IJA, Akron",Billy Gillen,M,USA,00:19:52.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1987,1987,3b 5km,Yes,"IJA, Akron",Clarke McFarlane,M,0,00:20:06.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1986,1986,3b Mile,Yes,"IJA, San Jose",Kirk Swenson,M,USA,00:04:43.00,1,http://www.juggling.org/orgs/ija/champs.txt http://www.juggling.org/jw/86/3/joggling.html
-1986,1986,3b Mile,Yes,"IJA, San Jose",Marty Gardella,M,0,00:05:44.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1986,1986,3b Mile,Yes,"IJA, San Jose",Mickey Campaniello,M,0,00:05:48.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1986,1986,3b 5km,Yes,"IJA, San Jose",Kirk Swenson,M,USA,00:16:58.00,1,http://www.juggling.org/orgs/ija/champs.txt  http://www.juggling.org/jw/86/3/joggling.html
-1986,1986,3b 5km,Yes,"IJA, San Jose",Mickey Campaniello,M,0,00:19:20.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1986,1986,3b 5km,Yes,"IJA, San Jose",Owen Morse,M,USA,00:20:27.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1985,1985,3b Mile,Yes,"IJA, Atlanta",Kirk Swenson,M,USA,00:04:47.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1985,1985,3b Mile,Yes,"IJA, Atlanta",Banks Helfrich,M,0,00:05:06.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1985,1985,3b Mile,Yes,"IJA, Atlanta",Andrew Head,M,0,00:05:47.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1984,1984,3b Mile,Yes,"IJA, Las Vegas",Kirk Swenson,M,USA,00:04:56.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1984,1984,3b Mile,Yes,"IJA, Las Vegas",Jim Piaskowy,M,0,00:05:06.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1984,1984,3b Mile,Yes,"IJA, Las Vegas",John Ellwanger,M,0,00:05:23.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1983,1983,3b Mile,Yes,"IJA, Purchase, NY",Michel Lauzière,M,CAN,00:05:25.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1983,1983,3b Mile,Yes,"IJA, Purchase, NY",Andrew Head,M,0,00:05:29.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1983,1983,3b Mile,Yes,"IJA, Purchase, NY",Paul Bernardo,M,0,00:05:38.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1983,1983,3b 5km,Yes,"IJA, Purchase, NY",Shidan Habib,M,0,00:19:35.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1983,1983,3b 5km,Yes,"IJA, Purchase, NY",Billy Gillen,M,USA,00:20:07.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1983,1983,3b 5km,Yes,"IJA, Purchase, NY",Michel Lauzière,M,CAN,00:20:09.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1983,1983,3c Marathon,No,Swindon Marathon,Colin Francome,M,GBR,04:26:00.00,?,"Phone call with Colin, August 2023"
-1982,1982,3b Mile,Yes,"IJA, Santa Barbara",Sean McLoughlin,M,0,00:05:15.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1982,1982,3b Mile,Yes,"IJA, Santa Barbara",Paul Williams,M,0,00:05:29.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1982,1982,3b Mile,Yes,"IJA, Santa Barbara",Bill Giduz,M,USA,00:05:36.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1982,1982,3b 5km,Yes,"IJA, Santa Barbara",Marty Gardella,M,0,00:18:47.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1982,1982,3b 5km,Yes,"IJA, Santa Barbara",Sean McLoughlin,M,0,00:19:00.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1982,1982,3b 5km,Yes,"IJA, Santa Barbara",David Marcias,M,0,00:19:51.00,?,http://www.juggling.org/orgs/ija/champs.txt
-1982,1982,3b Half Marathon,Yes,Montreal University Half Marathon,Michel Lauzière,M,CAN,01:19:00.00,?,Email exchange
+2023,2023,3b 5km,Yes,"IJA, Virtual",Daniel Raum,M,AUT,20:18.0,?,https://www.facebook.com/groups/372157942956062
+2023,2023,3b 5km,Yes,"IJA, Virtual",Brady Xue,M,USA,20:25.0,?,https://www.facebook.com/groups/372157942956062
+2023,2023,3b 5km,Yes,"IJA, Virtual",Christoph Mitasch,M,0,21:06.0,?,https://www.facebook.com/groups/372157942956062
+2023,2023,3b 5km,Yes,"IJA, Virtual",Sterling Franklin,M,USA,21:57.0,?,https://www.facebook.com/groups/372157942956062
+2023,2023,3b 5km,Yes,"IJA, Virtual",JoAnn Ireland,F,USA,39:23.0,?,https://www.facebook.com/groups/372157942956062
+2022,2022,3b Mile,Yes,"IJA, Virtual",Koutaro Kawano,M,JPN,06:41.0,0,https://www.strava.com/activities/7143549125
+2022,2022,3b Mile,Yes,"IJA, Virtual",Koutaro Kawano,M,JPN,06:48.0,3,https://www.strava.com/activities/7036273337
+2022,2022,3b Mile,Yes,"IJA, Virtual",Koutaro Kawano,M,JPN,06:51.0,1,https://www.strava.com/activities/7089450204
+2022,2022,3b 5km,Yes,"IJA, Virtual",Daniel Raum,M,AUT,19:58.0,?,https://www.juggle.org/enewsletter/2022-08
+2022,2022,3b 10km,Yes,Time Trial,Chris Edwin,M,GBR,36:02.0,0,
+2020,2020,3b Mile,Yes,"IJA, Virtual",Sterling Franklin,M,USA,05:29.0,?,https://www.juggle.org/festival-details/online-joggling-championships/
+2020,2020,3b Mile,Yes,"IJA, Virtual",Craig Muhlenkamp,M,USA,06:54.0,?,https://www.juggle.org/festival-details/online-joggling-championships/
+2020,2020,3b Mile,Yes,"IJA, Virtual",Marla Edgecomb,F,USA,10:45.0,?,https://www.juggle.org/festival-details/online-joggling-championships/
+2020,2020,3b 5km,Yes,"IJA, Virtual",Michael-Lucien Bergeron,M,CAN,16:49.0,0,https://www.juggle.org/festival-details/online-joggling-championships/
+2020,2020,3b 5km,Yes,"IJA, Virtual",Sterling Franklin,M,USA,19:43.0,?,https://www.juggle.org/festival-details/online-joggling-championships/
+2020,2020,3b 5km,Yes,"IJA, Virtual",Christoph Mitasch,M,0,23:34.0,?,https://www.juggle.org/festival-details/online-joggling-championships/
+2020,2020,3b 5km,Yes,"IJA, Virtual",Koutaro Kawano,M,JPN,24:07.0,?,https://www.juggle.org/festival-details/online-joggling-championships/
+2020,2020,3b 5km,Yes,"IJA, Virtual",Craig Muhlenkamp,M,USA,26:17.0,?,https://www.juggle.org/festival-details/online-joggling-championships/
+2020,2020,3b Marathon,Yes,New York Virtual Marathon,Barak Hirschowitz,M,USA,37:21.0,?,https://results.nyrr.org/event/20VMara/finishers#search=Barak%2520Hirschowitz
+2019,2019,3b 5km,Yes,Guelph 5km,Gabrielle Foran,F,CAN,20:42.0,?,https://sites.google.com/site/guelph5kjoggling/results
+2019,2019,3b 5km,Yes,Guelph 5km,Greg Philips,M,0,27:19.0,?,https://sites.google.com/site/guelph5kjoggling/results
+2019,2019,3b 5km,Yes,Guelph 5km,Mark Jolin,M,0,36:02.0,?,https://sites.google.com/site/guelph5kjoggling/results
+2019,2019,3b 17km,No,Wings for Life World Run,Levent Denizci,M,TUR,39:00.0,1,
+2019,2019,3b Half Marathon,Yes,Eskisehir Half Marathon,Levent Denizci,M,TUR,09:18.0,3,
+2019,2019,3b Half Marathon,Yes,Istanbul Half Marathon,Levent Denizci,M,TUR,10:05.0,2,
+2018,2018,3b 5km,Yes,Guelph 5km,Michal Kapral,M,CAN,19:05.0,?,https://sites.google.com/site/guelph5kjoggling/results
+2018,2018,3b 5km,Yes,Guelph 5km,Gabrielle Foran,F,CAN,19:09.0,?,https://sites.google.com/site/guelph5kjoggling/results
+2018,2018,3b 5km,Yes,Guelph 5km,Sydney McDonald,M,0,21:39.0,?,https://sites.google.com/site/guelph5kjoggling/results
+2018,2018,3b 5km,Yes,Guelph 5km,Morgan Anderson,F,0,24:42.0,?,https://sites.google.com/site/guelph5kjoggling/results
+2018,2018,3b 5km,Yes,Guelph 5km,Greg Philips,M,0,25:05.0,?,https://sites.google.com/site/guelph5kjoggling/results
+2018,2018,3b 5km,Yes,Guelph 5km,Ely Doan,M,0,26:05.0,?,https://sites.google.com/site/guelph5kjoggling/results
+2018,2018,3b 5km,Yes,Guelph 5km,Mike Moore,M,USA,26:20.0,?,https://sites.google.com/site/guelph5kjoggling/results
+2018,2018,3b 5km,Yes,Guelph 5km,David Pavlove Cunsolo,M,0,30:17.0,?,https://sites.google.com/site/guelph5kjoggling/results
+2018,2018,3b 15km,No,Istanbul,Levent Denizci,M,TUR,35:30.0,8,
+2018,2018,3b Half Marathon,Yes,Giresun Half Marathon,Levent Denizci,M,TUR,56:38.0,3,
+2018,2018,3b Half Marathon,Yes,Istanbul Half Marathon,Levent Denizci,M,TUR,59:31.0,4,
+2018,2018,3b Half Marathon,Yes,Edirne Half Marathon,Levent Denizci,M,TUR,17:35.0,9,
+2017,2017,3b 5km,Yes,Guelph 5km,Gabrielle Foran,F,CAN,19:12.0,?,https://sites.google.com/site/guelph5kjoggling/results
+2017,2017,3b 5km,Yes,"IJA, Lisbon, IA",Jacob Heimer,M,0,19:16.0,?,https://www.juggle.org/enewsletter/2017-07
+2017,2017,3b 5km,Yes,"IJA, Lisbon, IA",Gabrielle Foran,F,CAN,19:29.0,?,https://www.juggle.org/enewsletter/2017-07
+2017,2017,3b 5km,Yes,"IJA, Lisbon, IA",Bob Evans,M,USA,19:36.0,?,https://www.juggle.org/enewsletter/2017-07
+2017,2017,3b 5km,Yes,"IJA, Lisbon, IA",Erik Rain,M,0,20:26.0,?,https://www.juggle.org/enewsletter/2017-07
+2017,2017,3b 5km,Yes,"IJA, Lisbon, IA",Paul Arneberg,M,0,22:37.0,?,https://www.juggle.org/enewsletter/2017-07
+2017,2017,3b 5km,Yes,Guelph 5km,Julian Tam,M,0,23:49.0,?,https://sites.google.com/site/guelph5kjoggling/results
+2017,2017,3b 5km,Yes,"IJA, Lisbon, IA",Shahar Cohen,M,ISR,24:00.0,?,https://www.juggle.org/enewsletter/2017-07
+2017,2017,3b 5km,Yes,"IJA, Lisbon, IA",Katie Burgess,F,0,24:37.0,?,https://www.juggle.org/enewsletter/2017-07
+2017,2017,3b 5km,Yes,Guelph 5km,Boris Georgiev,M,0,24:42.0,?,https://sites.google.com/site/guelph5kjoggling/results
+2017,2017,3b 5km,Yes,"IJA, Lisbon, IA",Tony Malikowski,M,USA,24:42.0,?,https://www.juggle.org/enewsletter/2017-07
+2017,2017,3b 5km,Yes,"IJA, Lisbon, IA",Craig Wise,M,0,24:48.0,?,https://www.juggle.org/enewsletter/2017-07
+2017,2017,3b 5km,Yes,Guelph 5km,Tony Malikowski,M,USA,25:08.0,?,https://sites.google.com/site/guelph5kjoggling/results
+2017,2017,3b 5km,Yes,"IJA, Lisbon, IA",Jason Noye,M,0,26:15.0,?,https://www.juggle.org/enewsletter/2017-07
+2017,2017,3b 5km,Yes,"IJA, Lisbon, IA",Mike Moore,M,USA,27:11.0,?,https://www.juggle.org/enewsletter/2017-07
+2017,2017,3b 5km,Yes,"IJA, Lisbon, IA",Jared Ashton,M,0,27:51.0,?,https://www.juggle.org/enewsletter/2017-07
+2017,2017,3b 5km,Yes,"IJA, Lisbon, IA",Nathan Wakefield,M,0,27:56.0,?,https://www.juggle.org/enewsletter/2017-07
+2017,2017,3b 5km,Yes,"IJA, Lisbon, IA",Jack Hirschowitz,M,USA,28:21.0,?,https://www.juggle.org/enewsletter/2017-07
+2017,2017,3b 5km,Yes,Guelph 5km,Ely Doan,M,0,28:26.0,?,https://sites.google.com/site/guelph5kjoggling/results
+2017,2017,3b 5km,Yes,Guelph 5km,Gavin Hossack,M,0,30:07.0,?,https://sites.google.com/site/guelph5kjoggling/results
+2017,2017,3b 5km,Yes,"IJA, Lisbon, IA",Carter Randall,M,0,30:19.0,?,https://www.juggle.org/enewsletter/2017-07
+2017,2017,3b 5km,Yes,"IJA, Lisbon, IA",David Pavlove Cunsolo,M,0,30:22.0,?,https://www.juggle.org/enewsletter/2017-07
+2017,2017,3b 5km,Yes,"IJA, Lisbon, IA",Mary Geeves,F,0,32:10.0,?,https://www.juggle.org/enewsletter/2017-07
+2017,2017,3b 5km,Yes,Guelph 5km,David Pavlove Cunsolo,M,0,33:15.0,?,https://sites.google.com/site/guelph5kjoggling/results
+2017,2017,3b 5km,Yes,Guelph 5km,Eric Malikowski,M,0,34:45.0,?,https://sites.google.com/site/guelph5kjoggling/results
+2017,2017,3b 5km,Yes,"IJA, Lisbon, IA",Sarah Williams,F,0,45:37.0,?,https://www.juggle.org/enewsletter/2017-07
+2017,2017,3b 5km,Yes,"IJA, Lisbon, IA",Scott Randall,M,0,47:53.0,?,https://www.juggle.org/enewsletter/2017-07
+2017,2017,3c 10km,Yes,Ignite Istanbul,Levent Denizci,M,TUR,05:37.0,10,
+2017,2017,3b 15km,No,Istanbul,Ferda Tekgül,M,TUR,35:55.0,?,https://event.spor.istanbul/eventresults.aspx
+2017,2017,3c 15km,No,Istanbul,Levent Denizci,M,TUR,47:42.0,10,
+2016,2016,3b 5km,Yes,Guelph 5km,Gabrielle Foran,F,CAN,18:26.0,?,https://sites.google.com/site/guelph5kjoggling/results
+2016,2016,3b 5km,Yes,Guelph 5km,Julian Tam,M,0,23:22.0,?,https://sites.google.com/site/guelph5kjoggling/results
+2016,2016,3b 5km,Yes,Guelph 5km,Mike Moore,M,USA,23:56.0,?,https://sites.google.com/site/guelph5kjoggling/results
+2016,2016,3b 5km,Yes,Guelph 5km,Ely Doan,M,0,25:00.0,?,https://sites.google.com/site/guelph5kjoggling/results
+2016,2016,3b 5km,Yes,Guelph 5km,Boris Georgiev,M,0,29:45.0,?,https://sites.google.com/site/guelph5kjoggling/results
+2016,2016,3b 5km,Yes,Guelph 5km,David Pavlove Cunsolo,M,0,42:23.0,?,https://sites.google.com/site/guelph5kjoggling/results
+2016,2016,3b 10km,Yes,Ignite Istanbul,Levent Denizci,M,TUR,54:42.0,2,Levent shared a pdf doc of his results
+2016,2016,3b 13km,No,Wings for Life World Run,Levent Denizci,M,TUR,24:08.0,4,
+2016,2016,3b 15km,No,Istanbul,Levent Denizci,M,TUR,24:35.0,0,Levent shared a pdf doc of his results
+2015,2015,3b 26km,No,Istanbul,Levent Denizci,M,TUR,37:41.0,4,Levent shared a pdf doc of his results
+2014,2014,3b Half Marathon,Yes,Istanbul Half Marathon,Levent Denizci,M,TUR,01:19.0,3,https://www.instagram.com/p/BIl1YIKDEa0/
+2014,2014,3b Half Marathon,Yes,Runtalya,Levent Denizci,M,TUR,13:00.0,4,https://www.instagram.com/p/BIjUzCajyuf/
+2013,2013,3b 15km,No,Istanbul,Levent Denizci,M,TUR,12:49.0,7,Levent shared a pdf doc of his results
+2013,2013,3b 10km,Yes,Runtalya,Levent Denizci,M,TUR,14:27.0,12,https://www.instagram.com/p/BIg06QODG3d/
+2010,2010,3b 100m,Yes,"IJA, Nevada",Tyler Wishau,M,USA,00:13.9,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 100m,Yes,"IJA, Nevada",Chris Lovdal,M,0,00:13.9,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 100m,Yes,"IJA, Nevada",Dylan Waickman,M,0,00:14.2,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 100m,Yes,"IJA, Nevada",Joey Spicola,M,0,00:14.6,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 100m,Yes,"IJA, Nevada",Tim Hark,M,0,00:14.8,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 100m,Yes,"IJA, Nevada",Anders Kierulf,M,0,00:14.9,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 100m,Yes,"IJA, Nevada",Paul Arneberg,M,0,00:14.9,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 100m,Yes,"IJA, Nevada",Lauge Benjaminson,M,0,00:15.2,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 100m,Yes,"IJA, Nevada",Andrew Swan,M,0,00:15.2,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 100m,Yes,"IJA, Nevada",Andrew Hodge,M,0,00:15.3,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 100m,Yes,"IJA, Nevada",Dan Burke,M,0,00:15.4,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 100m,Yes,"IJA, Nevada",Chris Garcia,M,0,00:15.5,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 100m,Yes,"IJA, Nevada",Colin Revere,M,0,00:16.0,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 100m,Yes,"IJA, Nevada",Chris Olson,M,0,00:16.0,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 100m,Yes,"IJA, Nevada",Evan Peter,M,0,00:16.3,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 100m,Yes,"IJA, Nevada",Kyler McClintock,M,0,00:16.6,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 100m,Yes,"IJA, Nevada",Nick Hiniker,M,0,00:18.8,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 100m,Yes,"IJA, Nevada",Greg Meehan,M,0,00:18.8,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 100m,Yes,"IJA, Nevada",Justin Kolas,M,0,00:18.9,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 100m,Yes,"IJA, Nevada",Tom McClintock,M,0,00:19.3,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 100m,Yes,"IJA, Nevada",Jack Hirschowitz,M,USA,00:19.7,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 100m,Yes,"IJA, Nevada",Heather Marriott,F,USA,00:20.1,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 100m,Yes,"IJA, Nevada",Jack Levy,M,0,00:20.3,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 100m,Yes,"IJA, Nevada",Chris Dokler,M,0,00:20.7,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 100m,Yes,"IJA, Nevada",David Mlakar,M,0,00:20.9,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 100m,Yes,"IJA, Nevada",Neil Jordan,M,0,00:20.9,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 100m,Yes,"IJA, Nevada",Daniel Rose,M,0,00:21.5,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,5b 100m,Yes,"IJA, Nevada",Lauge Benjaminson,M,0,00:24.0,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 100m,Yes,"IJA, Nevada",Kevin Giblin,M,0,00:24.1,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 100m,Yes,"IJA, Nevada",Dan Chan,M,0,00:24.6,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 100m,Yes,"IJA, Nevada",Jacob Biesiada,M,0,00:25.0,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 100m,Yes,"IJA, Nevada",Scott Geyman,M,0,00:26.9,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 100m,Yes,"IJA, Nevada",Andrew Ruiz,M,0,00:27.4,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 100m,Yes,"IJA, Nevada",Sean Carney,M,0,00:27.6,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 100m,Yes,"IJA, Nevada",Brendan Cogan,M,0,00:28.6,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 100m,Yes,"IJA, Nevada",Alec Bennett,M,0,00:29.2,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 200m,Yes,"IJA, Nevada",Sean Carney,M,0,00:29.5,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 200m,Yes,"IJA, Nevada",Tyler Wishau,M,USA,00:30.5,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 200m,Yes,"IJA, Nevada",Tim Hark,M,0,00:30.9,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,5b 100m,Yes,"IJA, Nevada",Jack Levy,M,0,00:31.1,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 200m,Yes,"IJA, Nevada",Len Ferman,M,USA,00:31.9,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 200m,Yes,"IJA, Nevada",Jack Levy,M,0,00:32.2,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 200m,Yes,"IJA, Nevada",David Mlakar,M,0,00:32.3,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,5b 100m,Yes,"IJA, Nevada",Andrew Ruiz,M,0,00:32.4,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 200m,Yes,"IJA, Nevada",Joey Spicola,M,0,00:32.5,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 200m,Yes,"IJA, Nevada",Anders Kierulf,M,0,00:33.0,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 200m,Yes,"IJA, Nevada",Kevin Giblin,M,0,00:33.3,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 200m,Yes,"IJA, Nevada",Chris Lovdal,M,0,00:34.4,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,5b 100m,Yes,"IJA, Nevada",Tim Hark,M,0,00:34.8,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,5b 100m,Yes,"IJA, Nevada",Kyler McClintock,M,0,00:35.8,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 200m,Yes,"IJA, Nevada",Kyler McClintock,M,0,00:36.0,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 100m,Yes,"IJA, Nevada",Danny Hodge,M,0,00:36.5,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 200m,Yes,"IJA, Nevada",Neil Jordan,M,0,00:36.8,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 200m,Yes,"IJA, Nevada",Ricky Harr,M,0,00:37.3,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 200m,Yes,"IJA, Nevada",Andrew Hodge,M,0,00:37.4,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,5b 100m,Yes,"IJA, Nevada",Joey Spicola,M,0,00:37.7,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 200m,Yes,"IJA, Nevada",Daniel Rose,M,0,00:38.5,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 200m,Yes,"IJA, Nevada",Colin Revere,M,0,00:39.2,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 200m,Yes,"IJA, Nevada",Tom McClintock,M,0,00:39.3,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 100m,Yes,"IJA, Nevada",Jon Bozak,M,0,00:40.0,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 200m,Yes,"IJA, Nevada",Jack Hirschowitz,M,USA,00:41.4,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 200m,Yes,"IJA, Nevada",Chris Dokler,M,0,00:41.9,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 200m,Yes,"IJA, Nevada",Heather Marriott,F,USA,00:42.1,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 100m,Yes,"IJA, Nevada",Gordon Cornell,M,0,00:42.4,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 200m,Yes,"IJA, Nevada",Dylan Waickman,M,0,00:42.8,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,5b 100m,Yes,"IJA, Nevada",Evan Peter,M,0,00:43.9,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 200m,Yes,"IJA, Nevada",Paul Arneberg,M,0,00:45.8,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,5b 100m,Yes,"IJA, Nevada",David Mlakar,M,0,00:46.0,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 200m,Yes,"IJA, Nevada",Dan Chan,M,0,00:47.8,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 200m,Yes,"IJA, Nevada",Mike Swan,M,0,00:47.9,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,5b 100m,Yes,"IJA, Nevada",Andrew Hodge,M,0,00:51.6,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,5b 100m,Yes,"IJA, Nevada",Andrew Swan,M,0,00:54.9,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 200m,Yes,"IJA, Nevada",Danny Hodge,M,0,00:55.7,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,5b 100m,Yes,"IJA, Nevada",Daniel Rose,M,0,00:57.8,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,5b 100m,Yes,"IJA, Nevada",Colin Revere,M,0,00:58.0,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,7b 100m,Yes,"IJA, Nevada",Lauge Benjaminson,M,0,00:58.4,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 4x100m,Yes,"IJA, Nevada","Sean Carney, Chris Lovdal, Daniel Burke, Joey Spicola",#N/A,#N/A,00:58.8,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 200m,Yes,"IJA, Nevada",Gordon Cornell,M,0,00:59.3,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 4x100m,Yes,"IJA, Nevada","David Mlakar, Dylan Waickman, Tim Hark, Tyler Wishau",#N/A,#N/A,00:59.8,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,5b 100m,Yes,"IJA, Nevada",Tyler Wishau,M,USA,01:05.0,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,5b 100m,Yes,"IJA, Nevada",Chris Dokler,M,0,01:06.5,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 400m,Yes,"IJA, Nevada",Chris Lovdal,M,0,01:07.9,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 200m,Yes,"IJA, Nevada",Hannah Bowlin,F,0,01:08.4,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 400m,Yes,"IJA, Nevada",Dylan Waickman,M,0,01:08.5,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 400m,Yes,"IJA, Nevada",Tyler Wishau,M,USA,01:09.7,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 4x100m,Yes,"IJA, Nevada","Danny Rose, Colin Revere, Jack Levy, Ricky Harr",#N/A,#N/A,01:10.8,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,5b 100m,Yes,"IJA, Nevada",Nick Hiniker,M,0,01:11.8,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 400m,Yes,"IJA, Nevada",David Mlakar,M,0,01:12.8,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 400m,Yes,"IJA, Nevada",Tim Hark,M,0,01:13.1,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,5b 100m,Yes,"IJA, Nevada",Dylan Waickman,M,0,01:14.0,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 400m,Yes,"IJA, Nevada",Paul Arneberg,M,0,01:14.5,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,5b 100m,Yes,"IJA, Nevada",Chris Garcia,M,0,01:15.3,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 400m,Yes,"IJA, Nevada",Jack Levy,M,0,01:15.7,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 400m,Yes,"IJA, Nevada",Chris Olson,M,0,01:17.0,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 400m,Yes,"IJA, Nevada",Neil Jordan,M,0,01:19.3,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 4x100m,Yes,"IJA, Nevada","Andrew Hodge, Conor Hussey, Justin Kolas, Kylen McClintock",#N/A,#N/A,01:19.8,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 400m,Yes,"IJA, Nevada",Dan Burke,M,0,01:20.1,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 400m,Yes,"IJA, Nevada",Andrew Hodge,M,0,01:21.3,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 100m,Yes,"IJA, Nevada",Gay Shope,F,0,01:22.3,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 400m,Yes,"IJA, Nevada",Kyler McClintock,M,0,01:23.5,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 400m,Yes,"IJA, Nevada",Anders Kierulf,M,0,01:23.9,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 4x100m,Yes,"IJA, Nevada","Chris Dokler, Evan Peter, Kevin GIblin, Jon Bozak",#N/A,#N/A,01:26.4,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 400m,Yes,"IJA, Nevada",Evan Peter,M,0,01:26.7,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 4x100m,Yes,"IJA, Nevada","Anders Kierfulf, Andy Swan, Jack Hirshowitz, Tom McClintock",#N/A,#N/A,01:27.2,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 4x100m,Yes,"IJA, Nevada","Brendan Cogan, Jake Biesiada, Greg Meehan, Scott Geyman",#N/A,#N/A,01:27.4,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 400m,Yes,"IJA, Nevada",Tom McClintock,M,0,01:33.9,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 4x100m,Yes,"IJA, Nevada","Bob, Gordon Cornell, Paul Arneberg, Mike Swan",#N/A,#N/A,01:34.5,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,5b 100m,Yes,"IJA, Nevada",Mara Moettus,F,0,01:38.0,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 400m,Yes,"IJA, Nevada",Heather Marriott,F,USA,01:38.3,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 400m,Yes,"IJA, Nevada",Andrew Swan,M,0,01:41.2,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,5b 100m,Yes,"IJA, Nevada",Danny Hodge,M,0,01:42.0,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 400m,Yes,"IJA, Nevada",Alec Bennett,M,0,01:45.5,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,5b 100m,Yes,"IJA, Nevada",Meagan Nouis,F,0,01:49.0,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 400m,Yes,"IJA, Nevada",Colin Revere,M,0,01:49.5,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 400m,Yes,"IJA, Nevada",Dan Chan,M,0,01:50.2,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,7b 100m,Yes,"IJA, Nevada",Jack Levy,M,0,01:54.6,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,5b 100m,Yes,"IJA, Nevada",Tom McClintock,M,0,01:58.8,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 400m,Yes,"IJA, Nevada",Meagan Nouis,F,0,02:00.8,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 400m,Yes,"IJA, Nevada",Hannah Bowlin,F,0,02:06.4,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 400m,Yes,"IJA, Nevada",Danny Hodge,M,0,02:08.4,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 400m,Yes,"IJA, Nevada",Gordon Cornell,M,0,02:18.7,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 800m,Yes,"IJA, Nevada",Tyler Wishau,M,USA,02:23.6,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 800m,Yes,"IJA, Nevada",Len Ferman,M,USA,02:32.6,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 800m,Yes,"IJA, Nevada",Paul Arneberg,M,0,02:49.8,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 800m,Yes,"IJA, Nevada",Sean Carney,M,0,02:51.0,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 800m,Yes,"IJA, Nevada",Dylan Waickman,M,0,02:57.6,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 800m,Yes,"IJA, Nevada",Justin Kolas,M,0,02:58.1,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,7b 100m,Yes,"IJA, Nevada",Andrew Hodge,M,0,02:58.9,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 800m,Yes,"IJA, Nevada",Conor Hussey,M,0,03:03.1,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,7b 100m,Yes,"IJA, Nevada",Meagan Nouis,F,0,03:05.8,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 800m,Yes,"IJA, Nevada",David Mlakar,M,0,03:07.0,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 800m,Yes,"IJA, Nevada",Kevin Giblin,M,0,03:07.0,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 800m,Yes,"IJA, Nevada",Chris Garcia,M,0,03:07.8,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 800m,Yes,"IJA, Nevada",Andrew Swan,M,0,03:08.6,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 800m,Yes,"IJA, Nevada",Neil Jordan,M,0,03:09.3,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 800m,Yes,"IJA, Nevada",Andrew Ruiz,M,0,03:13.7,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 800m,Yes,"IJA, Nevada",Kyler McClintock,M,0,03:14.6,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 800m,Yes,"IJA, Nevada",Andrew Hodge,M,0,03:22.1,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 800m,Yes,"IJA, Nevada",Anders Kierulf,M,0,03:25.3,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,7b 100m,Yes,"IJA, Nevada",Joey Spicola,M,0,03:28.4,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 800m,Yes,"IJA, Nevada",Colin Revere,M,0,03:30.2,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 800m,Yes,"IJA, Nevada",Heather Marriott,F,USA,03:39.5,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 800m,Yes,"IJA, Nevada",Jack Hirschowitz,M,USA,03:59.5,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 4x400m,Yes,"IJA, Nevada","Dave Mlakar, Dylan Waickman, Tim Hark, Tyler Wishau",#N/A,#N/A,04:41.4,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 4x400m,Yes,"IJA, Nevada","Chris Lovdal, Paul Arneberg, Billy Watson, Sean Carney",#N/A,#N/A,04:42.8,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 800m,Yes,"IJA, Nevada",Gordon Cornell,M,0,04:59.3,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 800m,Yes,"IJA, Nevada",Danny Hodge,M,0,05:16.8,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 1600m,No,"IJA, Nevada",Billy Watson,M,0,05:27.0,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 4x400m,Yes,"IJA, Nevada","Joey Spicola, Colin Revere, Jack Levy, Len Ferman",#N/A,#N/A,05:31.7,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 1600m,No,"IJA, Nevada",Len Ferman,M,USA,05:51.0,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 4x400m,Yes,"IJA, Nevada","Andrew Hodge, Kylen McClintock, Kevin Giblin, Greg Meehan",#N/A,#N/A,05:59.2,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 1600m,No,"IJA, Nevada",Tyler Wishau,M,USA,06:05.0,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,7b 100m,Yes,"IJA, Nevada",Mara Moettus,F,0,06:09.5,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 4x400m,Yes,"IJA, Nevada","Andy Swan, Tom McClintock, Anders Kierulf, Jack Hirshowitz",#N/A,#N/A,06:46.0,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 1600m,No,"IJA, Nevada",Justin Kolas,M,0,06:48.0,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 1600m,No,"IJA, Nevada",Conor Hussey,M,0,07:04.0,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 4x400m,Yes,"IJA, Nevada","Scott Geyman, Brendan Cogan, Jon Bozak, Chris Dokler",#N/A,#N/A,07:20.9,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 4x400m,Yes,"IJA, Nevada","Mike Swan, Larry Kluger, Gordon Cornell, Bob The Jockey",#N/A,#N/A,07:50.7,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 1600m,No,"IJA, Nevada",Neil Jordan,M,0,07:54.0,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 1600m,No,"IJA, Nevada",Andrew Hodge,M,0,08:06.0,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 1600m,No,"IJA, Nevada",Tom McClintock,M,0,08:15.0,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 1600m,No,"IJA, Nevada",Alec Bennett,M,0,09:02.0,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 1600m,No,"IJA, Nevada",Larry Kluger,M,0,09:29.0,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 1600m,No,"IJA, Nevada",Jacob Biesiada,M,0,09:35.0,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 1600m,No,"IJA, Nevada",Dan Chan,M,0,11:22.0,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 5km,Yes,"IJA, Nevada",Tyler Wishau,M,USA,19:41.0,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 5km,Yes,"IJA, Nevada",Chris Garcia,M,0,23:52.0,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 5km,Yes,"IJA, Nevada",Andrew Swan,M,0,27:23.0,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 5km,Yes,"IJA, Nevada",Jack Hirschowitz,M,USA,27:33.0,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 5km,Yes,"IJA, Nevada",Dean Bennett,M,0,27:40.0,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 5km,Yes,"IJA, Nevada",Andrew Hodge,M,0,29:01.0,?,https://dev.juggle.org/history/champs/champs2010.php
+2010,2010,3b 5km,Yes,"IJA, Nevada",Gordon Cornell,M,0,37:43.0,?,https://dev.juggle.org/history/champs/champs2010.php
+2008,2008,3b 10km,Yes,"Ukrops Monument Avenue 10k (Richmond, VA)",Jesse Joyner,M,USA,00:29.0,?,https://www.trackshackresults.com/richmond/results/2008/10k_results.php?Link=46&Type=3&LName=Joyner&FName=Jesse&City=&State=&Country=
+2008,2008,3b Half Marathon,Yes,"McDonalds Half Marathon (Richmond, VA)",Jesse Joyner,M,USA,34:05.0,?,https://www.trackshackresults.com/richmond/results/2008/hm_results.php?Link=22&Type=3&LName=Joyner&FName=Jesse&City=&State=&Country=
+2007,2007,3b 5km,Yes,Time Trial,Tyler Wishau,M,USA,17:08.0,0,https://thejoggler.blogspot.com/2007/12/best-joggles-of-2007.html
+2007,2007,3b Marathon,Yes,Tampa Bay Marathon,Perry Romanowski,M,USA,23:00.0,?,
+2005,2005,3b 5km,Yes,Berlin,Perry Romanowski,M,USA,19:48.0,?,
+1998,1998,3b 5km,Yes,EJC,Mike Hebebrand,M,USA,19:00.0,?,From Email exchange with Mike (April 2023)
+1997,1997,3b 100m,Yes,"IJA, Pittsburgh",David Hussey,M,0,00:13.9,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,3b 100m,Yes,"IJA, Pittsburgh",Barry Goldmeier,M,USA,00:14.1,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,3b 100m,Yes,"IJA, Pittsburgh",Darin Marriott,M,USA,00:14.9,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,3b 100m,Yes,"IJA, Pittsburgh",Bill Giduz,M,USA,00:15.4,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,3b 100m,Yes,"IJA, Pittsburgh",Travis Saunders,M,CAN,00:15.7,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,3b 100m,Yes,"IJA, Pittsburgh",Melinda Paas,F,0,00:17.0,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,3b 100m,Yes,"IJA, Pittsburgh",Aaron Olson,M,0,00:17.5,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,3b 100m,Yes,"IJA, Pittsburgh",Dorothy Finnigan,F,0,00:17.7,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,3b 100m,Yes,"IJA, Pittsburgh",Sandy Brown,F,0,00:17.7,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,3b 100m,Yes,"IJA, Pittsburgh",Brent Beebe,M,0,00:18.0,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,3b 100m,Yes,"IJA, Pittsburgh",Scott Anthony,M,0,00:18.1,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,3b 100m,Yes,"IJA, Pittsburgh",Tucker Weisman,M,0,00:18.3,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,3b 100m,Yes,"IJA, Pittsburgh",Robert Sandberg,M,0,00:18.3,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,3b 100m,Yes,"IJA, Pittsburgh",Becky Provance,F,0,00:18.3,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,3b 100m,Yes,"IJA, Pittsburgh",Laura Provance,F,0,00:18.6,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,3b 100m,Yes,"IJA, Pittsburgh",Kelsey Deutch,F,0,00:18.8,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,5b 100m,Yes,"IJA, Pittsburgh",Ben Schoenberg,M,0,00:19.7,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,3b 100m,Yes,"IJA, Pittsburgh",Sam Kilbourn,M,0,00:20.6,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,3b 100m,Yes,"IJA, Pittsburgh",Heather Marriott,F,USA,00:20.8,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,3b 100m,Yes,"IJA, Pittsburgh",Peter Fry,M,0,00:21.3,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,3b 100m,Yes,"IJA, Pittsburgh",Jerry Battenfield,M,0,00:23.9,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,3b 100m,Yes,"IJA, Pittsburgh",Brian McAllister,M,0,00:26.0,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,5b 100m,Yes,"IJA, Pittsburgh",Barry Goldmeier,M,USA,00:26.2,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,3b 100m,Yes,"IJA, Pittsburgh",Matt Henstridge,M,0,00:31.3,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,5b 100m,Yes,"IJA, Pittsburgh",Marlin Ballard,M,0,00:38.2,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,3b 400m,Yes,"IJA, Pittsburgh",Curt Hoffman,M,0,01:07.4,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,3b 400m,Yes,"IJA, Pittsburgh",Bill Giduz,M,USA,01:11.4,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,3b 400m,Yes,"IJA, Pittsburgh",David Hussey,M,0,01:16.0,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,3b 400m,Yes,"IJA, Pittsburgh",George Faust,M,0,01:17.2,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,3b 400m,Yes,"IJA, Pittsburgh",Travis Saunders,M,CAN,01:25.0,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,3b 400m,Yes,"IJA, Pittsburgh",Mark Kolbusz,M,0,01:27.0,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,3b 400m,Yes,"IJA, Pittsburgh",Melinda Paas,F,0,01:27.6,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,3b 400m,Yes,"IJA, Pittsburgh",Sam Kilbourn,M,0,01:28.9,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,3b 400m,Yes,"IJA, Pittsburgh",Sandy Brown,F,0,01:31.0,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,3b 400m,Yes,"IJA, Pittsburgh",Becky Provance,F,0,01:32.0,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,3b 400m,Yes,"IJA, Pittsburgh",Laura Provance,F,0,01:33.0,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,3b 400m,Yes,"IJA, Pittsburgh",Kelsey Deutch,F,0,01:34.1,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,3b 400m,Yes,"IJA, Pittsburgh",Marion Caldwell,F,0,01:37.6,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,3b 400m,Yes,"IJA, Pittsburgh",Aaron Olson,M,0,01:40.0,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,3b 400m,Yes,"IJA, Pittsburgh",Tucker Weisman,M,0,01:40.0,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,3b 400m,Yes,"IJA, Pittsburgh",Peter Fry,M,0,01:41.0,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,3b 400m,Yes,"IJA, Pittsburgh",Dorothy Finnigan,F,0,01:48.5,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,3b 400m,Yes,"IJA, Pittsburgh",Dave Gedeon,M,0,01:50.0,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,3b Mile,Yes,"IJA, Pittsburgh",Reese Edwards,M,0,05:13.0,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,3b Mile,Yes,"IJA, Pittsburgh",Mark Kolbus,M,0,05:48.0,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,3b Mile,Yes,"IJA, Pittsburgh",Curt Hoffman,M,0,06:03.0,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,3b Mile,Yes,"IJA, Pittsburgh",Mickey Campaniello,M,0,06:13.0,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,3b Mile,Yes,"IJA, Pittsburgh",Heather Marriott,F,USA,06:47.0,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,3b Mile,Yes,"IJA, Pittsburgh",Charles Williams,M,0,07:10.0,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,3b Mile,Yes,"IJA, Pittsburgh",Tim Baird,M,0,07:15.0,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,3b Mile,Yes,"IJA, Pittsburgh",David Groth,M,0,07:35.0,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,3b Mile,Yes,"IJA, Pittsburgh",Marion Caldwell,F,0,07:35.0,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,3b Mile,Yes,"IJA, Pittsburgh",Becky Provance,F,0,09:10.0,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,3b Mile,Yes,"IJA, Pittsburgh",Laura Provance,F,0,09:10.0,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,3b Mile,Yes,"IJA, Pittsburgh",Laurie Young,F,0,09:31.0,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,3b 5km,Yes,"IJA, Pittsburgh",Reese Edwards,M,0,18:21.0,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,3b 5km,Yes,"IJA, Pittsburgh",Darin Marriott,M,USA,18:43.0,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,3b 5km,Yes,"IJA, Pittsburgh",Mark Kolbus,M,0,20:50.0,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,3b 5km,Yes,"IJA, Pittsburgh",Mickey Campaniello,M,0,21:37.0,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,3b 5km,Yes,"IJA, Pittsburgh",Jerry Kurtz,M,0,22:29.0,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,3b 5km,Yes,"IJA, Pittsburgh",George Faust,M,0,23:14.0,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,3b 5km,Yes,"IJA, Pittsburgh",Heather Marriott,F,USA,23:45.0,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,3b 5km,Yes,"IJA, Pittsburgh",Kay Caskey,F,0,26:57.0,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,3b 5km,Yes,"IJA, Pittsburgh",Marion Caldwell,F,0,26:57.0,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,3b 5km,Yes,"IJA, Pittsburgh",Scott Anthony,M,0,27:22.0,?,https://dev.juggle.org/history/champs/champs1997.php
+1997,1997,3b 5km,Yes,"IJA, Pittsburgh",Natalie McIntyre,F,0,28:48.0,?,https://dev.juggle.org/history/champs/champs1997.php
+1996,1996,3b 100m,Yes,"IJA, Rapid City",Albert Lucas,M,USA,00:13.1,?,https://dev.juggle.org/history/champs/champs1996.php
+1996,1996,3b 100m,Yes,"IJA, Rapid City",Andrew Swan,M,0,00:14.8,?,https://dev.juggle.org/history/champs/champs1996.php
+1996,1996,3b 100m,Yes,"IJA, Rapid City",Barry Goldmeier,M,USA,00:14.9,?,https://dev.juggle.org/history/champs/champs1996.php
+1996,1996,3b 100m,Yes,"IJA, Rapid City",Bill Giduz,M,USA,00:16.1,?,https://dev.juggle.org/history/champs/champs1996.php
+1996,1996,3b 100m,Yes,"IJA, Rapid City",Chuck Hawley,M,0,00:16.6,?,https://dev.juggle.org/history/champs/champs1996.php
+1996,1996,3b 100m,Yes,"IJA, Rapid City",Keith Tollefson,M,0,00:16.6,?,https://dev.juggle.org/history/champs/champs1996.php
+1996,1996,3b 100m,Yes,"IJA, Rapid City",Joe Dean,M,0,00:17.1,?,https://dev.juggle.org/history/champs/champs1996.php
+1996,1996,3b 100m,Yes,"IJA, Rapid City",Sam Kilbourn,M,0,00:17.3,?,https://dev.juggle.org/history/champs/champs1996.php
+1996,1996,3b 100m,Yes,"IJA, Rapid City",Daniel Margulis,M,0,00:18.2,?,https://dev.juggle.org/history/champs/champs1996.php
+1996,1996,3b 100m,Yes,"IJA, Rapid City",Adam Griffon,M,0,00:19.9,?,https://dev.juggle.org/history/champs/champs1996.php
+1996,1996,3b 100m,Yes,"IJA, Rapid City",Aaron Olson,M,0,00:20.0,?,https://dev.juggle.org/history/champs/champs1996.php
+1996,1996,3b 100m,Yes,"IJA, Rapid City",Laura Green,F,0,00:20.1,?,https://dev.juggle.org/history/champs/champs1996.php
+1996,1996,3b 100m,Yes,"IJA, Rapid City",Joseph Hout,M,0,00:20.9,?,https://dev.juggle.org/history/champs/champs1996.php
+1996,1996,3b 100m,Yes,"IJA, Rapid City",Shawn Bryan,M,0,00:21.2,?,https://dev.juggle.org/history/champs/champs1996.php
+1996,1996,3b 100m,Yes,"IJA, Rapid City",Elizabeth Sanberg,F,0,00:21.6,?,https://dev.juggle.org/history/champs/champs1996.php
+1996,1996,3b 100m,Yes,"IJA, Rapid City",Meghan Cain,F,0,00:23.6,?,https://dev.juggle.org/history/champs/champs1996.php
+1996,1996,3b 100m,Yes,"IJA, Rapid City",Elizabeth Sanberg,F,0,00:23.8,?,https://dev.juggle.org/history/champs/champs1996.php
+1996,1996,3b 100m,Yes,"IJA, Rapid City",Ian Caldwell,M,0,00:24.5,?,https://dev.juggle.org/history/champs/champs1996.php
+1996,1996,5b 100m,Yes,"IJA, Rapid City",Ben Schoenberg,M,0,00:25.4,?,https://dev.juggle.org/history/champs/champs1996.php
+1996,1996,5b 100m,Yes,"IJA, Rapid City",Mike Hout,M,0,00:25.7,?,https://dev.juggle.org/history/champs/champs1996.php
+1996,1996,3b 100m,Yes,"IJA, Rapid City",Marion Caldwell,F,0,00:26.2,?,https://dev.juggle.org/history/champs/champs1996.php
+1996,1996,3b 100m,Yes,"IJA, Rapid City",Nick Bartucci,M,0,00:31.5,?,https://dev.juggle.org/history/champs/champs1996.php
+1996,1996,3b 100m,Yes,"IJA, Rapid City",Corinne Ozolins,F,0,00:33.4,?,https://dev.juggle.org/history/champs/champs1996.php
+1996,1996,3b 400m,Yes,"IJA, Rapid City",Albert Lucas,M,USA,01:00.9,?,https://dev.juggle.org/history/champs/champs1996.php
+1996,1996,5b 100m,Yes,"IJA, Rapid City",Dan Kirk,M,0,01:01.0,?,https://dev.juggle.org/history/champs/champs1996.php
+1996,1996,3b 400m,Yes,"IJA, Rapid City",Andrew Swan,M,0,01:05.4,?,https://dev.juggle.org/history/champs/champs1996.php
+1996,1996,3b 400m,Yes,"IJA, Rapid City",Ben Schoenberg,M,0,01:06.2,?,https://dev.juggle.org/history/champs/champs1996.php
+1996,1996,3b 400m,Yes,"IJA, Rapid City",Paul Arneberg,M,0,01:07.5,?,https://dev.juggle.org/history/champs/champs1996.php
+1996,1996,3b 400m,Yes,"IJA, Rapid City",Bill Giduz,M,USA,01:12.0,?,https://dev.juggle.org/history/champs/champs1996.php
+1996,1996,5b 100m,Yes,"IJA, Rapid City",Andrew Swan,M,0,01:17.0,?,https://dev.juggle.org/history/champs/champs1996.php
+1996,1996,3b 400m,Yes,"IJA, Rapid City",Shawn Bryan,M,0,01:19.0,?,https://dev.juggle.org/history/champs/champs1996.php
+1996,1996,3b 400m,Yes,"IJA, Rapid City",Chuck Hawley,M,0,01:24.0,?,https://dev.juggle.org/history/champs/champs1996.php
+1996,1996,3b 400m,Yes,"IJA, Rapid City",Keith Tollefson,M,0,01:27.0,?,https://dev.juggle.org/history/champs/champs1996.php
+1996,1996,3b 400m,Yes,"IJA, Rapid City",Daniel Margulis,M,0,01:31.0,?,https://dev.juggle.org/history/champs/champs1996.php
+1996,1996,3b 400m,Yes,"IJA, Rapid City",Aaron Olson,M,0,01:34.0,?,https://dev.juggle.org/history/champs/champs1996.php
+1996,1996,3b 400m,Yes,"IJA, Rapid City",Meghan Cain,F,0,01:37.0,?,https://dev.juggle.org/history/champs/champs1996.php
+1996,1996,3b 400m,Yes,"IJA, Rapid City",Iman deLachotta-Lizarazu,F,0,01:42.0,?,https://dev.juggle.org/history/champs/champs1996.php
+1996,1996,3b 400m,Yes,"IJA, Rapid City",Laura Green,F,0,02:06.0,?,https://dev.juggle.org/history/champs/champs1996.php
+1996,1996,3b 4x400m,Yes,"IJA, Rapid City","Bill Giduz, Sam Kilbourn, Robert Nelson, Albert Lucas",#N/A,#N/A,05:17.0,?,https://dev.juggle.org/history/champs/champs1996.php
+1996,1996,3b Mile,Yes,"IJA, Rapid City",Albert Lucas,M,USA,05:27.0,?,https://dev.juggle.org/history/champs/champs1996.php
+1996,1996,3b 4x400m,Yes,"IJA, Rapid City","Adam Griffin, Shawn Bryan, Daniel Margulies, Chuck Howlie",#N/A,#N/A,05:28.0,?,https://dev.juggle.org/history/champs/champs1996.php
+1996,1996,3b Mile,Yes,"IJA, Rapid City",Paul Arneberg,M,0,05:39.0,?,https://dev.juggle.org/history/champs/champs1996.php
+1996,1996,3b Mile,Yes,"IJA, Rapid City",Reese Edwards,M,0,05:46.0,?,https://dev.juggle.org/history/champs/champs1996.php
+1996,1996,3b Mile,Yes,"IJA, Rapid City",Keith Baker,M,0,06:05.0,?,https://dev.juggle.org/history/champs/champs1996.php
+1996,1996,3b Mile,Yes,"IJA, Rapid City",Adam Griffin,M,0,06:07.0,?,https://dev.juggle.org/history/champs/champs1996.php
+1996,1996,3b 4x400m,Yes,"IJA, Rapid City","Matt Henstridge, Greg Blaha, Nick Bartucci, Reece Edwards",#N/A,#N/A,06:48.0,?,https://dev.juggle.org/history/champs/champs1996.php
+1996,1996,3b 4x400m,Yes,"IJA, Rapid City","Keith Tollefson, Meghan Cain, Aaron Olson, Robert Sanberg",#N/A,#N/A,07:17.0,?,https://dev.juggle.org/history/champs/champs1996.php
+1996,1996,3b 4x400m,Yes,"IJA, Rapid City","Kay Caskey, Laurie Young, Laura Green, Iman deLachotta-Lizarazu",#N/A,#N/A,08:26.0,?,https://dev.juggle.org/history/champs/champs1996.php
+1996,1996,3b Mile,Yes,"IJA, Rapid City",Daniel Margulis,M,0,08:31.0,?,https://dev.juggle.org/history/champs/champs1996.php
+1996,1996,3b Mile,Yes,"IJA, Rapid City",Chuck Hawley,M,0,08:31.0,?,https://dev.juggle.org/history/champs/champs1996.php
+1996,1996,3b Mile,Yes,"IJA, Rapid City",Marion Caldwell,F,0,10:07.0,?,https://dev.juggle.org/history/champs/champs1996.php
+1996,1996,3b Mile,Yes,"IJA, Rapid City",Kay Caskey,F,0,10:12.0,?,https://dev.juggle.org/history/champs/champs1996.php
+1996,1996,5b Mile,Yes,"IJA, Rapid City",Ben Schoenberg,M,0,10:36.0,?,https://dev.juggle.org/history/champs/champs1996.php
+1996,1996,5b Mile,Yes,"IJA, Rapid City",Barry Goldmeier,M,USA,10:37.0,?,https://dev.juggle.org/history/champs/champs1996.php
+1996,1996,3b 5km,Yes,"IJA, Rapid City",Reese Edwards,M,0,20:17.0,?,https://dev.juggle.org/history/champs/champs1996.php
+1996,1996,3b 5km,Yes,"IJA, Rapid City",Keith Baker,M,0,21:38.0,?,https://dev.juggle.org/history/champs/champs1996.php
+1996,1996,3b 5km,Yes,"IJA, Rapid City",Andrew Swan,M,0,23:21.0,?,https://dev.juggle.org/history/champs/champs1996.php
+1996,1996,3b 5km,Yes,"IJA, Rapid City",Ben Schoenberg,M,0,24:38.0,?,https://dev.juggle.org/history/champs/champs1996.php
+1996,1996,5b 5km,Yes,"IJA, Rapid City",Barry Goldmeier,M,USA,27:53.0,?,https://dev.juggle.org/history/champs/champs1996.php
+1996,1996,3b 5km,Yes,"IJA, Rapid City",Bill Coad,M,USA,29:56.0,?,https://dev.juggle.org/history/champs/champs1996.php
+1996,1996,3b 5km,Yes,"IJA, Rapid City",Laurie Young,F,0,34:02.0,?,https://dev.juggle.org/history/champs/champs1996.php
+1995,1995,3b 100m,Yes,"IJA, Las Vegas",Barry Goldmeier,M,USA,00:15.5,?,https://dev.juggle.org/history/champs/champs1995.php
+1995,1995,3b 100m,Yes,"IJA, Las Vegas",Jim Steffens,M,0,00:16.1,?,https://dev.juggle.org/history/champs/champs1995.php
+1995,1995,3b 100m,Yes,"IJA, Las Vegas",Franz Roos,M,0,00:17.1,?,https://dev.juggle.org/history/champs/champs1995.php
+1995,1995,3b 100m,Yes,"IJA, Las Vegas",Ben Hout,M,0,00:17.2,?,https://dev.juggle.org/history/champs/champs1995.php
+1995,1995,3b 100m,Yes,"IJA, Las Vegas",Bill Giduz,M,USA,00:17.3,?,https://dev.juggle.org/history/champs/champs1995.php
+1995,1995,3b 100m,Yes,"IJA, Las Vegas",Larry Boehmer,M,0,00:19.2,?,https://dev.juggle.org/history/champs/champs1995.php
+1995,1995,3b 100m,Yes,"IJA, Las Vegas",Cam Fleming,M,0,00:19.7,?,https://dev.juggle.org/history/champs/champs1995.php
+1995,1995,3b 100m,Yes,"IJA, Las Vegas",Keith Baker,M,0,00:24.2,?,https://dev.juggle.org/history/champs/champs1995.php
+1995,1995,5b 100m,Yes,"IJA, Las Vegas",Mike Hout,M,0,00:27.3,?,https://dev.juggle.org/history/champs/champs1995.php
+1995,1995,5b 100m,Yes,"IJA, Las Vegas",Ben Schoenberg,M,0,00:27.8,?,https://dev.juggle.org/history/champs/champs1995.php
+1995,1995,3b 100m,Yes,"IJA, Las Vegas",Joseph Hout,M,0,00:28.1,?,https://dev.juggle.org/history/champs/champs1995.php
+1995,1995,3b 100m,Yes,"IJA, Las Vegas",Ivan Hernandez,M,0,00:28.7,?,https://dev.juggle.org/history/champs/champs1995.php
+1995,1995,3b 100m,Yes,"IJA, Las Vegas",Cindy Hout,F,0,00:28.7,?,https://dev.juggle.org/history/champs/champs1995.php
+1995,1995,3b 100m,Yes,"IJA, Las Vegas",Dorothy Finnigan,F,0,00:29.4,?,https://dev.juggle.org/history/champs/champs1995.php
+1995,1995,3b 100m,Yes,"IJA, Las Vegas",Becky Provance,F,0,00:29.5,?,https://dev.juggle.org/history/champs/champs1995.php
+1995,1995,3b 100m,Yes,"IJA, Las Vegas",Michelle Grossman,F,0,00:32.7,?,https://dev.juggle.org/history/champs/champs1995.php
+1995,1995,3b 100m,Yes,"IJA, Las Vegas",Jane Birkhead,F,0,00:35.9,?,https://dev.juggle.org/history/champs/champs1995.php
+1995,1995,5b 100m,Yes,"IJA, Las Vegas",Daniel Hout,M,0,00:56.5,?,https://dev.juggle.org/history/champs/champs1995.php
+1995,1995,3b 400m,Yes,"IJA, Las Vegas",Franz Roos,M,0,01:05.4,?,https://dev.juggle.org/history/champs/champs1995.php
+1995,1995,3b 400m,Yes,"IJA, Las Vegas",Barry Goldmeier,M,USA,01:06.0,?,https://dev.juggle.org/history/champs/champs1995.php
+1995,1995,3b 400m,Yes,"IJA, Las Vegas",Ben Schoenberg,M,0,01:09.0,?,https://dev.juggle.org/history/champs/champs1995.php
+1995,1995,3b 400m,Yes,"IJA, Las Vegas",Cam Fleming,M,0,01:20.0,?,https://dev.juggle.org/history/champs/champs1995.php
+1995,1995,3b 400m,Yes,"IJA, Las Vegas",Becky Provance,F,0,01:42.0,?,https://dev.juggle.org/history/champs/champs1995.php
+1995,1995,3b 400m,Yes,"IJA, Las Vegas",Daniel Margulis,M,0,01:52.0,?,https://dev.juggle.org/history/champs/champs1995.php
+1995,1995,3b 400m,Yes,"IJA, Las Vegas",Jane Birkhead,F,0,02:01.0,?,https://dev.juggle.org/history/champs/champs1995.php
+1995,1995,3b 400m,Yes,"IJA, Las Vegas",Laurie Young,F,0,02:12.0,?,https://dev.juggle.org/history/champs/champs1995.php
+1995,1995,3b 4x400m,Yes,"IJA, Las Vegas","Keith Baker, Barry Goldmeier, Ben Schoenberg, Jim Steffens",#N/A,#N/A,05:13.0,?,https://dev.juggle.org/history/champs/champs1995.php
+1995,1995,3b 4x400m,Yes,"IJA, Las Vegas","Larry Boehmer, Bill Giduz, Mike Hout, Bob Neuman",#N/A,#N/A,05:39.0,?,https://dev.juggle.org/history/champs/champs1995.php
+1995,1995,3b Mile,Yes,"IJA, Las Vegas",Mike Hebebrand,M,USA,05:42.0,?,https://dev.juggle.org/history/champs/champs1995.php
+1995,1995,3b Mile,Yes,"IJA, Las Vegas",Keith Baker,M,0,06:01.0,?,https://dev.juggle.org/history/champs/champs1995.php
+1995,1995,3b Mile,Yes,"IJA, Las Vegas",Reese Edwards,M,0,06:11.0,?,https://dev.juggle.org/history/champs/champs1995.php
+1995,1995,3b Mile,Yes,"IJA, Las Vegas",Becky Provance,F,0,08:57.0,?,https://dev.juggle.org/history/champs/champs1995.php
+1995,1995,3b Mile,Yes,"IJA, Las Vegas",Laurie Young,F,0,09:22.0,?,https://dev.juggle.org/history/champs/champs1995.php
+1995,1995,3b 4x400m,Yes,"IJA, Las Vegas","Kay Caskey, Cindy Hout, Roni Lynn, Laurie Young",#N/A,#N/A,10:04.0,?,https://dev.juggle.org/history/champs/champs1995.php
+1995,1995,3b 5km,Yes,"IJA, Las Vegas",Mike Hebebrand,M,USA,19:54.0,?,https://dev.juggle.org/history/champs/champs1995.php
+1995,1995,3b 5km,Yes,"IJA, Las Vegas",Sam Wildofsky,M,0,20:37.0,?,https://dev.juggle.org/history/champs/champs1995.php
+1995,1995,3b 5km,Yes,"IJA, Las Vegas",Reese Edwards,M,0,22:37.0,?,https://dev.juggle.org/history/champs/champs1995.php
+1995,1995,5b 5km,Yes,"IJA, Las Vegas",Barry Goldmeier,M,USA,33:03.0,?,https://dev.juggle.org/history/champs/champs1995.php
+1995,1995,3b 5km,Yes,"IJA, Las Vegas",Kay Caskey,F,0,36:14.0,?,https://dev.juggle.org/history/champs/champs1995.php
+1994,1994,3b 100m,Yes,"IJA, Vermont",Albert Lucas,M,USA,00:13.2,?,https://dev.juggle.org/history/champs/champs1994.php
+1994,1994,3b 100m,Yes,"IJA, Vermont",Tom Sparough,M,0,00:15.2,?,https://dev.juggle.org/history/champs/champs1994.php
+1994,1994,3b 100m,Yes,"IJA, Vermont",Marlin Ballard,M,0,00:15.3,?,https://dev.juggle.org/history/champs/champs1994.php
+1994,1994,3b 100m,Yes,"IJA, Vermont",Bill Giduz,M,USA,00:16.2,?,https://dev.juggle.org/history/champs/champs1994.php
+1994,1994,3b 100m,Yes,"IJA, Vermont",Ben Hout,M,0,00:17.7,?,https://dev.juggle.org/history/champs/champs1994.php
+1994,1994,3b 100m,Yes,"IJA, Vermont",Daniel Hout,M,0,00:20.8,?,https://dev.juggle.org/history/champs/champs1994.php
+1994,1994,3b 100m,Yes,"IJA, Vermont",Joseph Hout,M,0,00:28.0,?,https://dev.juggle.org/history/champs/champs1994.php
+1994,1994,5b 100m,Yes,"IJA, Vermont",Mike Hout,M,0,00:32.5,?,https://dev.juggle.org/history/champs/champs1994.php
+1994,1994,5b 100m,Yes,"IJA, Vermont",Ben Schoenberg,M,0,00:44.5,?,https://dev.juggle.org/history/champs/champs1994.php
+1994,1994,5b 100m,Yes,"IJA, Vermont",Tom Sparough,M,0,00:48.5,?,https://dev.juggle.org/history/champs/champs1994.php
+1994,1994,5b 100m,Yes,"IJA, Vermont",Daniel Hout,M,0,00:52.9,?,https://dev.juggle.org/history/champs/champs1994.php
+1994,1994,3b 400m,Yes,"IJA, Vermont",Albert lucas,M,USA,01:02.2,?,https://dev.juggle.org/history/champs/champs1994.php
+1994,1994,3b 400m,Yes,"IJA, Vermont",John Zaleskie,M,0,01:05.3,?,https://dev.juggle.org/history/champs/champs1994.php
+1994,1994,3b 400m,Yes,"IJA, Vermont",Darren Samson,M,0,01:10.0,?,https://dev.juggle.org/history/champs/champs1994.php
+1994,1994,5b 100m,Yes,"IJA, Vermont",Joanne Swain,F,0,01:14.0,?,https://dev.juggle.org/history/champs/champs1994.php
+1994,1994,3b 400m,Yes,"IJA, Vermont",Joanne Swain,F,0,01:48.2,?,https://dev.juggle.org/history/champs/champs1994.php
+1994,1994,3b 400m,Yes,"IJA, Vermont",Cindy Hout,F,0,02:14.0,?,https://dev.juggle.org/history/champs/champs1994.php
+1994,1994,3b 4x400m,Yes,"IJA, Vermont","Albert Lucas, John Zaleskie",#N/A,#N/A,04:37.0,?,https://dev.juggle.org/history/champs/champs1994.php
+1994,1994,3b 4x400m,Yes,"IJA, Vermont","Bill Giduz, Mike Hout, Darren Samson, Dan Fitzgerald",#N/A,#N/A,04:58.0,?,https://dev.juggle.org/history/champs/champs1994.php
+1994,1994,3b Mile,Yes,"IJA, Vermont",Albert Lucas,M,USA,05:48.2,?,https://dev.juggle.org/history/champs/champs1994.php
+1994,1994,3b Mile,Yes,"IJA, Vermont",Keith Baker,M,0,05:56.0,?,https://dev.juggle.org/history/champs/champs1994.php
+1994,1994,3b Mile,Yes,"IJA, Vermont",Joe Lyons,M,0,06:57.0,?,https://dev.juggle.org/history/champs/champs1994.php
+1994,1994,3b 4x400m,Yes,"IJA, Vermont","Joanne Swain, Ben Hout, Joseph Hout, Daniel Hout",#N/A,#N/A,08:25.0,?,https://dev.juggle.org/history/champs/champs1994.php
+1994,1994,3b Mile,Yes,"IJA, Vermont",Bob Neuman,M,0,08:27.2,?,https://dev.juggle.org/history/champs/champs1994.php
+1994,1994,3b Mile,Yes,"IJA, Vermont",Chuck Worrell,M,0,09:10.0,?,https://dev.juggle.org/history/champs/champs1994.php
+1994,1994,3b 4x400m,Yes,"IJA, Vermont","Laurie Young, Roni Lynn, Kay Caskey, Cindy Hout",#N/A,#N/A,09:43.0,?,https://dev.juggle.org/history/champs/champs1994.php
+1994,1994,3b 5km,Yes,"IJA, Vermont",Albert Lucas,M,USA,20:50.0,?,"https://dev.juggle.org/history/champs/champs1994.php, Billy Gillen Memorial 5km"
+1994,1994,3b 5km,Yes,"IJA, Vermont",Keith Baker,M,0,21:03.0,?,"https://dev.juggle.org/history/champs/champs1994.php, Billy Gillen Memorial 5km"
+1994,1994,3b 5km,Yes,"IJA, Vermont",Darren Samson,M,0,22:30.0,?,"https://dev.juggle.org/history/champs/champs1994.php, Billy Gillen Memorial 5km"
+1994,1994,3b 5km,Yes,"IJA, Vermont",Laurie Young,F,0,33:13.0,?,"https://dev.juggle.org/history/champs/champs1994.php, Billy Gillen Memorial 5km"
+1993,1993,3b 100m,Yes,"IJA, Fargo",Michael Nance,M,0,00:15.4,?,http://www.juggling.org/orgs/ija/champs.txt
+1993,1993,3b 100m,Yes,"IJA, Fargo",Mike Hout,M,0,00:15.6,?,http://www.juggling.org/orgs/ija/champs.txt
+1993,1993,3b 100m,Yes,"IJA, Fargo",Mark Kolbus,M,0,00:17.1,?,http://www.juggling.org/orgs/ija/champs.txt
+1993,1993,3b 100m,Yes,"IJA, Fargo",Paul Williamson,M,0,00:17.4,?,http://www.juggling.org/orgs/ija/champs.txt
+1993,1993,3b 100m,Yes,"IJA, Fargo",Bill Giduz,M,USA,00:17.5,?,http://www.juggling.org/orgs/ija/champs.txt
+1993,1993,3b 100m,Yes,"IJA, Fargo",Dan Fitzgerald,M,0,00:18.7,?,http://www.juggling.org/orgs/ija/champs.txt
+1993,1993,3b 100m,Yes,"IJA, Fargo",Joanne Swain,F,0,00:20.7,?,http://www.juggling.org/orgs/ija/champs.txt
+1993,1993,3b 100m,Yes,"IJA, Fargo",Ben Hout,M,0,00:21.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1993,1993,3b 100m,Yes,"IJA, Fargo",Carol Mills,F,0,00:21.7,?,http://www.juggling.org/orgs/ija/champs.txt
+1993,1993,3b 100m,Yes,"IJA, Fargo",Laura Green,F,0,00:22.3,?,http://www.juggling.org/orgs/ija/champs.txt
+1993,1993,3b 100m,Yes,"IJA, Fargo",Daniel Hout,M,0,00:23.2,?,http://www.juggling.org/orgs/ija/champs.txt
+1993,1993,3b 100m,Yes,"IJA, Fargo",Joseph Hout,M,0,00:25.1,?,http://www.juggling.org/orgs/ija/champs.txt
+1993,1993,3b 100m,Yes,"IJA, Fargo",Sandy Amass,F,0,00:27.9,?,http://www.juggling.org/orgs/ija/champs.txt
+1993,1993,3b 100m,Yes,"IJA, Fargo",Cindy Hout,F,0,00:30.5,?,http://www.juggling.org/orgs/ija/champs.txt
+1993,1993,3b 100m,Yes,"IJA, Fargo",Laurie Young,F,0,00:30.5,?,http://www.juggling.org/orgs/ija/champs.txt
+1993,1993,3b 100m,Yes,"IJA, Fargo",John Phipps,M,0,00:31.2,?,http://www.juggling.org/orgs/ija/champs.txt
+1993,1993,3b 100m,Yes,"IJA, Fargo",Dave Finnigan,M,0,00:32.2,?,http://www.juggling.org/orgs/ija/champs.txt
+1993,1993,3b 400m,Yes,"IJA, Fargo",Sean McKinney,M,0,01:07.1,?,http://www.juggling.org/orgs/ija/champs.txt
+1993,1993,3b 400m,Yes,"IJA, Fargo",Ben Schoenberg,M,0,01:07.4,?,http://www.juggling.org/orgs/ija/champs.txt
+1993,1993,3b 400m,Yes,"IJA, Fargo",Mark Kolbus,M,0,01:08.4,?,http://www.juggling.org/orgs/ija/champs.txt
+1993,1993,3b 400m,Yes,"IJA, Fargo",Bill Giduz,M,USA,01:10.5,?,http://www.juggling.org/orgs/ija/champs.txt
+1993,1993,3b 400m,Yes,"IJA, Fargo",Richard Courter,M,0,01:13.3,?,http://www.juggling.org/orgs/ija/champs.txt
+1993,1993,3b 400m,Yes,"IJA, Fargo",Joanne Swain,F,0,01:39.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1993,1993,3b 400m,Yes,"IJA, Fargo",Laura Green,F,0,01:44.5,?,http://www.juggling.org/orgs/ija/champs.txt
+1993,1993,3b 400m,Yes,"IJA, Fargo",Carol Mills,F,0,01:52.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1993,1993,3b 400m,Yes,"IJA, Fargo",Laurie Young,F,0,01:57.1,?,http://www.juggling.org/orgs/ija/champs.txt
+1993,1993,3b 400m,Yes,"IJA, Fargo",Sandy Amass,F,0,02:06.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1993,1993,3b 400m,Yes,"IJA, Fargo",Jane Hussey,F,0,02:16.7,?,http://www.juggling.org/orgs/ija/champs.txt
+1993,1993,3b 4x400m,Yes,"IJA, Fargo","Robin Chestnut, Troy Fitzgerald, Bob Hartman, Sean McKinney",#N/A,#N/A,04:46.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1993,1993,3b 4x400m,Yes,"IJA, Fargo","Richard Courter, Dan Fitzgerald, Mark Fountain, Bill Giduz",#N/A,#N/A,05:14.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1993,1993,3b 4x400m,Yes,"IJA, Fargo","Mike Hout, Michael Nance, Eric Norby, Paul Williamson",#N/A,#N/A,05:37.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1993,1993,3b Mile,Yes,"IJA, Fargo",Mark Kolbus,M,0,05:46.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1993,1993,3b Mile,Yes,"IJA, Fargo",Troy Fitzgerald,M,0,06:07.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1993,1993,3b Mile,Yes,"IJA, Fargo",Jim Shellard,M,0,06:25.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1993,1993,3b Mile,Yes,"IJA, Fargo",Nick Matsakis,M,0,07:24.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1993,1993,3b 4x400m,Yes,"IJA, Fargo","Sandy Amass, Kathy Glynn, Carol Mills, Joanne Swain",#N/A,#N/A,07:43.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1993,1993,3b Mile,Yes,"IJA, Fargo",Kathy Glynn,F,0,07:57.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1993,1993,3b 4x400m,Yes,"IJA, Fargo","Kay Caskey, Laura Green, Jane Hussey, Laurie Young",#N/A,#N/A,08:07.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1993,1993,3b 4x400m,Yes,"IJA, Fargo","David Czarnoto, Ben Hout, Daniel Hout, Joseph Hout",#N/A,#N/A,09:28.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1993,1993,3b Mile,Yes,"IJA, Fargo",Laurie Young,F,0,09:33.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1993,1993,3b Mile,Yes,"IJA, Fargo",Carol Mills,F,0,11:15.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1993,1993,3b 5km,Yes,"IJA, Fargo",Mike Hebebrand,M,USA,18:35.9,?,http://www.juggling.org/orgs/ija/champs.txt
+1993,1993,3b 5km,Yes,"IJA, Fargo",Jay Pittman ,M,0,22:34.4,?,http://www.juggling.org/orgs/ija/champs.txt
+1993,1993,3b 5km,Yes,"IJA, Fargo",Ben Schoenberg,M,0,22:35.5,?,http://www.juggling.org/orgs/ija/champs.txt
+1993,1993,3b 5km,Yes,"IJA, Fargo",Bill Coad,M,USA,24:36.6,?,http://www.juggling.org/orgs/ija/champs.txt
+1993,1993,3b 5km,Yes,"IJA, Fargo",Kay Caskey,F,0,29:31.9,?,http://www.juggling.org/orgs/ija/champs.txt
+1992,1992,3b 100m,Yes,"IJA, Quebec",Barry Goldmeier,M,USA,00:13.4,?,http://www.juggling.org/orgs/ija/champs.txt
+1992,1992,3b 100m,Yes,"IJA, Quebec",Mike Hout,M,0,00:13.4,?,http://www.juggling.org/orgs/ija/champs.txt
+1992,1992,3b 100m,Yes,"IJA, Quebec",Joe Lyons,M,0,00:14.5,?,http://www.juggling.org/orgs/ija/champs.txt
+1992,1992,3b 100m,Yes,"IJA, Quebec",Michael Nance,M,0,00:14.6,?,http://www.juggling.org/orgs/ija/champs.txt
+1992,1992,3b 100m,Yes,"IJA, Quebec",Jay Casper,M,0,00:16.2,?,http://www.juggling.org/orgs/ija/champs.txt
+1992,1992,3b 100m,Yes,"IJA, Quebec",Cam Fleming,M,0,00:17.2,?,http://www.juggling.org/orgs/ija/champs.txt
+1992,1992,3b 100m,Yes,"IJA, Quebec",Joanne Swain,F,0,00:18.9,?,http://www.juggling.org/orgs/ija/champs.txt
+1992,1992,3b 100m,Yes,"IJA, Quebec",Joanne Swain,F,0,00:18.9,?,http://www.juggling.org/orgs/ija/champs.txt
+1992,1992,3b 100m,Yes,"IJA, Quebec",Daniel Hout,M,0,00:19.5,?,http://www.juggling.org/orgs/ija/champs.txt
+1992,1992,3b 100m,Yes,"IJA, Quebec",Paul Williamson,M,0,00:20.1,?,http://www.juggling.org/orgs/ija/champs.txt
+1992,1992,3b 100m,Yes,"IJA, Quebec",Johan DuHoffman,M,0,00:20.2,?,http://www.juggling.org/orgs/ija/champs.txt
+1992,1992,3b 100m,Yes,"IJA, Quebec",Nicholas Tackis,M,0,00:21.2,?,http://www.juggling.org/orgs/ija/champs.txt
+1992,1992,3b 100m,Yes,"IJA, Quebec",Jamie Cordes,M,0,00:21.2,?,http://www.juggling.org/orgs/ija/champs.txt
+1992,1992,3b 100m,Yes,"IJA, Quebec",Joanne Dintzis,F,0,00:29.1,?,http://www.juggling.org/orgs/ija/champs.txt
+1992,1992,3b 100m,Yes,"IJA, Quebec",Cindy Hout,F,0,00:29.5,?,http://www.juggling.org/orgs/ija/champs.txt
+1992,1992,5b 100m,Yes,"IJA, Quebec",Marlin Ballard,M,0,00:32.7,?,http://www.juggling.org/orgs/ija/champs.txt
+1992,1992,5b 100m,Yes,"IJA, Quebec",Cam Fleming,M,0,00:42.3,?,http://www.juggling.org/orgs/ija/champs.txt
+1992,1992,3b 400m,Yes,"IJA, Quebec",Barry Goldmeier,M,USA,01:06.2,?,http://www.juggling.org/orgs/ija/champs.txt
+1992,1992,3b 400m,Yes,"IJA, Quebec",Ben Schoenberg,M,0,01:07.2,?,http://www.juggling.org/orgs/ija/champs.txt
+1992,1992,3b 400m,Yes,"IJA, Quebec",Richard Courter,M,0,01:09.5,?,http://www.juggling.org/orgs/ija/champs.txt
+1992,1992,3b 400m,Yes,"IJA, Quebec",Kathy Glynn,F,0,01:30.4,?,http://www.juggling.org/orgs/ija/champs.txt
+1992,1992,3b 400m,Yes,"IJA, Quebec",Joanne Swain,F,0,01:46.8,?,http://www.juggling.org/orgs/ija/champs.txt
+1992,1992,3b 400m,Yes,"IJA, Quebec",Laura Green,F,0,01:48.6,?,http://www.juggling.org/orgs/ija/champs.txt
+1992,1992,3b 4x400m,Yes,"IJA, Quebec","Mike Hout, Michael Nance, Eric Norby, Paul Williamson",#N/A,#N/A,04:53.6,?,http://www.juggling.org/orgs/ija/champs.txt
+1992,1992,3b 4x400m,Yes,"IJA, Quebec","Paul Ballard, Richard Courter, Mark Fontaine, Barry Goldmeier",#N/A,#N/A,05:00.7,?,http://www.juggling.org/orgs/ija/champs.txt
+1992,1992,3b 4x400m,Yes,"IJA, Quebec","Robin Chestnut, Troy Fitzgerald, Bob Hartman, Sean McKinney",#N/A,#N/A,05:01.8,?,http://www.juggling.org/orgs/ija/champs.txt
+1992,1992,3b Mile,Yes,"IJA, Quebec",Troy Fitzgerald,M,0,05:30.1,?,http://www.juggling.org/orgs/ija/champs.txt
+1992,1992,3b Mile,Yes,"IJA, Quebec",Robin Chestnut,M,0,05:54.3,?,http://www.juggling.org/orgs/ija/champs.txt
+1992,1992,3b Mile,Yes,"IJA, Quebec",Joe Lyons,M,0,06:13.7,?,http://www.juggling.org/orgs/ija/champs.txt
+1992,1992,3b 4x400m,Yes,"IJA, Quebec","Kathy Glynn, Laura Green, Joanne Swain, Laurie Young",#N/A,#N/A,07:08.5,?,http://www.juggling.org/orgs/ija/champs.txt
+1992,1992,3b 4x400m,Yes,"IJA, Quebec","Ben Hout, Daniel Hout, Joseph Hout, Nicholas Tackis",#N/A,#N/A,08:37.4,?,http://www.juggling.org/orgs/ija/champs.txt
+1992,1992,3b Mile,Yes,"IJA, Quebec",Kay Caskey,F,0,08:45.1,?,http://www.juggling.org/orgs/ija/champs.txt
+1992,1992,3b Mile,Yes,"IJA, Quebec",Andrea Goranson,F,0,10:56.6,?,http://www.juggling.org/orgs/ija/champs.txt
+1992,1992,3b 5km,Yes,"IJA, Quebec",Ben Schoenberg,M,0,19:48.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1992,1992,3b 5km,Yes,"IJA, Quebec",Troy Fitzgerald,M,0,20:00.8,?,http://www.juggling.org/orgs/ija/champs.txt
+1992,1992,3b 5km,Yes,"IJA, Quebec",Sam Wildofsky,M,0,20:25.8,?,http://www.juggling.org/orgs/ija/champs.txt
+1992,1992,3b 5km,Yes,"IJA, Quebec",Laurie Young,F,0,27:42.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1992,1992,3b 5km,Yes,"IJA, Quebec",Roni Lynn,F,0,32:48.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1991,1991,3b 100m,Yes,"IJA, St. Louis",Mike Hout,M,0,00:13.7,?,http://www.juggling.org/orgs/ija/champs.txt
+1991,1991,3b 100m,Yes,"IJA, St. Louis",Barry Goldmeier,M,USA,00:14.2,?,http://www.juggling.org/orgs/ija/champs.txt
+1991,1991,3b 100m,Yes,"IJA, St. Louis",Jim Steffens,M,0,00:14.6,?,http://www.juggling.org/orgs/ija/champs.txt
+1991,1991,3b 100m,Yes,"IJA, St. Louis",Bill Giduz,M,USA,00:15.7,?,http://www.juggling.org/orgs/ija/champs.txt
+1991,1991,3b 100m,Yes,"IJA, St. Louis",Laura Green,F,0,00:17.5,?,http://www.juggling.org/orgs/ija/champs.txt
+1991,1991,3b 100m,Yes,"IJA, St. Louis",Sandy Amass,F,0,00:20.2,?,http://www.juggling.org/orgs/ija/champs.txt
+1991,1991,3b 100m,Yes,"IJA, St. Louis",Jane Hussey,F,0,00:22.8,?,http://www.juggling.org/orgs/ija/champs.txt
+1991,1991,3b 100m,Yes,"IJA, St. Louis",Joanne Swain,F,0,00:24.5,?,http://www.juggling.org/orgs/ija/champs.txt
+1991,1991,3b 100m,Yes,"IJA, St. Louis",Karen Phariss,F,0,00:25.4,?,http://www.juggling.org/orgs/ija/champs.txt
+1991,1991,3b 100m,Yes,"IJA, St. Louis",Laurie Young,F,0,00:25.4,?,http://www.juggling.org/orgs/ija/champs.txt
+1991,1991,3b 100m,Yes,"IJA, St. Louis",Daniel Hout,M,0,00:28.7,?,http://www.juggling.org/orgs/ija/champs.txt
+1991,1991,3b 400m,Yes,"IJA, St. Louis",Barry Goldmeier,M,USA,01:04.9,?,http://www.juggling.org/orgs/ija/champs.txt
+1991,1991,3b 400m,Yes,"IJA, St. Louis",Mike Hout,M,0,01:08.4,?,http://www.juggling.org/orgs/ija/champs.txt
+1991,1991,3b 400m,Yes,"IJA, St. Louis",Bill Giduz,M,USA,01:09.1,?,http://www.juggling.org/orgs/ija/champs.txt
+1991,1991,3b 400m,Yes,"IJA, St. Louis",Jim Steffens,M,0,01:10.9,?,http://www.juggling.org/orgs/ija/champs.txt
+1991,1991,3b 400m,Yes,"IJA, St. Louis",Will Howard,M,USA,01:46.1,?,http://www.juggling.org/orgs/ija/champs.txt
+1991,1991,3b 400m,Yes,"IJA, St. Louis",Laura Green,F,0,01:51.9,?,http://www.juggling.org/orgs/ija/champs.txt
+1991,1991,3b 400m,Yes,"IJA, St. Louis",Laurie Young,F,0,01:57.9,?,http://www.juggling.org/orgs/ija/champs.txt
+1991,1991,3b 400m,Yes,"IJA, St. Louis",Joanne Swain,F,0,01:59.4,?,http://www.juggling.org/orgs/ija/champs.txt
+1991,1991,3b 400m,Yes,"IJA, St. Louis",Sandy Amass,F,0,02:07.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1991,1991,3b 4x400m,Yes,"IJA, St. Louis","Anthony Gatto, Barry Goldmeier, John Kilgust, Jim Steffens",#N/A,#N/A,04:38.8,?,http://www.juggling.org/orgs/ija/champs.txt
+1991,1991,3b 4x400m,Yes,"IJA, St. Louis","Driggers, Bill Giduz, Billy Gillen, Gary Vice",#N/A,#N/A,04:41.9,?,http://www.juggling.org/orgs/ija/champs.txt
+1991,1991,3b 4x400m,Yes,"IJA, St. Louis","Fleming, Mike Thomason, Joe Welling, Wolcott",#N/A,#N/A,04:57.4,?,http://www.juggling.org/orgs/ija/champs.txt
+1991,1991,3b 1600m,No,"IJA, St. Louis",Troy Fitzgerald,M,0,05:05.8,?,http://www.juggling.org/orgs/ija/champs.txt
+1991,1991,3b 1600m,No,"IJA, St. Louis",Steve Otteson,M,0,05:44.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1991,1991,3b 1600m,No,"IJA, St. Louis",Ben Schoenberg,M,0,05:54.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1991,1991,3b 4x400m,Yes,"IJA, St. Louis","Barlow, Fountain, Mike Hout, Ignasiask",#N/A,#N/A,05:58.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1991,1991,3b 1600m,No,"IJA, St. Louis",Robin Chestnut,M,0,06:00.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1991,1991,3b 1600m,No,"IJA, St. Louis",Kathy Glynn,F,0,07:00.5,?,http://www.juggling.org/orgs/ija/champs.txt
+1991,1991,3b 4x400m,Yes,"IJA, St. Louis","Kay Caskey, Kathy Glynn, Laura Green, Laurie Young",#N/A,#N/A,07:30.3,?,http://www.juggling.org/orgs/ija/champs.txt
+1991,1991,3b 1600m,No,"IJA, St. Louis",Laurie Young,F,0,09:10.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1991,1991,3b 4x400m,Yes,"IJA, St. Louis","Victoria Amick, Risa Davis, Karen Phariss, Joanne Swain",#N/A,#N/A,10:04.2,?,http://www.juggling.org/orgs/ija/champs.txt
+1991,1991,3b 5km,Yes,"IJA, St. Louis",John Kilgust,M,0,20:41.8,?,http://www.juggling.org/orgs/ija/champs.txt
+1991,1991,3b 5km,Yes,"IJA, St. Louis",Billy Gillen,M,USA,21:49.4,?,http://www.juggling.org/orgs/ija/champs.txt
+1991,1991,3b 5km,Yes,"IJA, St. Louis",Joe Lyons,M,0,22:09.2,?,http://www.juggling.org/orgs/ija/champs.txt
+1991,1991,3b 5km,Yes,"IJA, St. Louis",Steve Otteson,M,0,22:36.1,?,http://www.juggling.org/orgs/ija/champs.txt
+1991,1991,3b 5km,Yes,"IJA, St. Louis",Kay Caskey,F,0,30:13.4,?,http://www.juggling.org/orgs/ija/champs.txt
+1990,1990,3b 100m,Yes,"IJA, LA",Owen Morse,M,USA,00:12.1,?,http://www.juggling.org/orgs/ija/champs.txt
+1990,1990,3b 100m,Yes,"IJA, LA",Albert Lucas,M,USA,00:12.9,?,http://www.juggling.org/orgs/ija/champs.txt
+1990,1990,3b 100m,Yes,"IJA, LA",Barry Goldmeier,M,USA,00:14.3,?,http://www.juggling.org/orgs/ija/champs.txt
+1990,1990,3b 100m,Yes,"IJA, LA",Sandy Brown,F,0,00:17.2,?,http://www.juggling.org/orgs/ija/champs.txt
+1990,1990,3b 100m,Yes,"IJA, LA",Christa Rypins,F,0,00:19.2,?,http://www.juggling.org/orgs/ija/champs.txt
+1990,1990,3b 400m,Yes,"IJA, LA",Owen Morse,M,USA,00:57.4,?,http://www.juggling.org/orgs/ija/champs.txt
+1990,1990,3b 400m,Yes,"IJA, LA",Albert Lucas,M,USA,01:04.5,?,http://www.juggling.org/orgs/ija/champs.txt
+1990,1990,3b 400m,Yes,"IJA, LA",Barry Goldmeier,M,USA,01:06.8,?,http://www.juggling.org/orgs/ija/champs.txt
+1990,1990,3b 400m,Yes,"IJA, LA",Christa Rypins,F,0,01:16.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1990,1990,3b 4x400m,Yes,"IJA, LA","Albert Lucas, Owen Morse, Jon Wee, Tuey Wilson",#N/A,#N/A,03:57.4,?,http://www.juggling.org/orgs/ija/champs.txt
+1990,1990,3b 4x400m,Yes,"IJA, LA","Lars Rohrback, Jim Steffens, Michael Taylor, Mike Thomason",#N/A,#N/A,04:44.3,?,http://www.juggling.org/orgs/ija/champs.txt
+1990,1990,3b 4x400m,Yes,"IJA, LA","Scott Anthony, Bill Giduz, Barry Goldmeier, John Kilgust",#N/A,#N/A,04:51.9,?,http://www.juggling.org/orgs/ija/champs.txt
+1990,1990,3b Mile,Yes,"IJA, LA",Mike Hebebrand,M,USA,05:16.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1990,1990,3b Mile,Yes,"IJA, LA",Mark Branner,M,0,05:38.2,?,http://www.juggling.org/orgs/ija/champs.txt
+1990,1990,3b Mile,Yes,"IJA, LA",Christa Rypins,F,0,06:43.4,?,http://www.juggling.org/orgs/ija/champs.txt
+1990,1990,3b 4x400m,Yes,"IJA, LA","Sandy Brown, Kay Caskey, Kathy Glynn, Laurie Young",#N/A,#N/A,06:54.1,?,http://www.juggling.org/orgs/ija/champs.txt
+1990,1990,3b Mile,Yes,"IJA, LA",Kathy Glynn,F,0,07:34.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1990,1990,3b Mile,Yes,"IJA, LA",Kay Caskey,F,0,08:44.6,?,http://www.juggling.org/orgs/ija/champs.txt
+1990,1990,3b 5km,Yes,"IJA, LA",Mike Hebebrand,M,USA,17:37.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1990,1990,3b 5km,Yes,"IJA, LA",Robert Slick,M,0,17:55.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1990,1990,3b 5km,Yes,"IJA, LA",John Kilgust,M,0,20:08.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1990,1990,3b 5km,Yes,"IJA, LA",Laurie Young,F,0,29:15.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1990,1990,3b 10km,Yes,Time Trial,Mike Hebebrand,M,USA,35:45.0,?,From Email exchange with Mike (April 2023)
+1989,1989,3b 100m,Yes,"IJA, Baltimore",Jeff Mason,M,0,00:13.2,?,http://www.juggling.org/orgs/ija/champs.txt
+1989,1989,3b 100m,Yes,"IJA, Baltimore",Tuey Wilson,M,0,00:13.3,?,http://www.juggling.org/orgs/ija/champs.txt
+1989,1989,3b 100m,Yes,"IJA, Baltimore",Tom Sparough,M,0,00:13.9,?,http://www.juggling.org/orgs/ija/champs.txt
+1989,1989,3b 100m,Yes,"IJA, Baltimore",Laura Green,F,0,00:18.3,?,http://www.juggling.org/orgs/ija/champs.txt
+1989,1989,3b 100m,Yes,"IJA, Baltimore",KC Canter,F,0,00:19.7,?,http://www.juggling.org/orgs/ija/champs.txt
+1989,1989,3b 100m,Yes,"IJA, Baltimore",Joanne Dintzis,F,0,00:21.9,?,http://www.juggling.org/orgs/ija/champs.txt
+1989,1989,3b 4x400m,Yes,"IJA, Baltimore","Albert Lucas, Owen Morse, Jon Wee, Tuey Wilson",#N/A,#N/A,04:01.5,?,http://www.juggling.org/orgs/ija/champs.txt
+1989,1989,3b 4x400m,Yes,"IJA, Baltimore","Steve Otteson, Jim Steffens, Lars Rohrbach, John Kilgust",#N/A,#N/A,04:41.3,?,http://www.juggling.org/orgs/ija/champs.txt
+1989,1989,3b 4x400m,Yes,"IJA, Baltimore","Marlin Ballard, Tom Sparough, Barry Goldmeier, Mike Narotsk",#N/A,#N/A,05:11.1,?,http://www.juggling.org/orgs/ija/champs.txt
+1989,1989,3b Mile,Yes,"IJA, Baltimore",Steve Otteson,M,0,05:41.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1989,1989,3b Mile,Yes,"IJA, Baltimore",Bill Giduz,M,USA,05:47.8,?,http://www.juggling.org/orgs/ija/champs.txt
+1989,1989,3b Mile,Yes,"IJA, Baltimore",Mike Thomasen,M,0,05:51.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1989,1989,3b Mile,Yes,"IJA, Baltimore",Kathy Glynn,F,0,06:17.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1989,1989,5b Mile,Yes,Time Trial,Billy Gillen,M,USA,07:41.0,?,"https://www.dev.juggle.org/history/archives/jugmags/45-2/45-2,p11.htm"
+1989,1989,3b 5km,Yes,"IJA, Baltimore",John Kilgust,M,0,19:06.7,?,http://www.juggling.org/orgs/ija/champs.txt
+1989,1989,3b 5km,Yes,"IJA, Baltimore",Steve Otteson,M,0,20:33.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1989,1989,3b 5km,Yes,"IJA, Baltimore",Paul Ballard,M,0,20:50.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1989,1989,3b 5km,Yes,"IJA, Baltimore",Kay Caskey,F,0,27:57.7,?,http://www.juggling.org/orgs/ija/champs.txt
+1989,1989,5b 5km,Yes,Time Trial,Billy Gillen,M,USA,28:11.0,?,"https://www.dev.juggle.org/history/archives/jugmags/45-2/45-2,p11.htm"
+1988,1988,3b 100m,Yes,"IJA, Denver",Owen Morse,M,USA,00:11.9,?,http://www.juggling.org/orgs/ija/champs.txt
+1988,1988,3b 100m,Yes,"IJA, Denver",Albert Lucas,M,USA,00:12.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1988,1988,3b 100m,Yes,"IJA, Denver",Tom Sparough,M,0,00:14.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1988,1988,3b 100m,Yes,"IJA, Denver",Sandy Brown,F,0,00:18.8,?,http://www.juggling.org/orgs/ija/champs.txt
+1988,1988,3b 100m,Yes,"IJA, Denver",Tina Fraser,F,0,00:22.4,?,http://www.juggling.org/orgs/ija/champs.txt
+1988,1988,3b 100m,Yes,"IJA, Denver",Joanne Dintzis,F,0,00:25.1,?,http://www.juggling.org/orgs/ija/champs.txt
+1988,1988,3b 4x400m,Yes,"IJA, Denver","Albert Lucas, Owen Morse, Jon Wee, Tuey Wilson",#N/A,#N/A,04:05.4,?,http://www.juggling.org/orgs/ija/champs.txt
+1988,1988,3b Mile,Yes,"IJA, Denver",Albert Lucas,M,USA,05:35.8,?,http://www.juggling.org/orgs/ija/champs.txt
+1988,1988,3b Mile,Yes,"IJA, Denver",Steve Wilson,M,0,05:39.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1988,1988,3b Mile,Yes,"IJA, Denver",John Ellwanger,M,0,05:51.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1988,1988,3b 4x400m,Yes,"IJA, Denver","Sarah Breckenridge, Kay Caskey, Joanne Dintzis, Tina Fraser",#N/A,#N/A,07:57.4,?,http://www.juggling.org/orgs/ija/champs.txt
+1988,1988,3b Mile,Yes,"IJA, Denver",Tina Fraser,F,0,09:40.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1988,1988,3b Mile,Yes,"IJA, Denver",Sarah Breckenridge,F,0,10:03.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1988,1988,3b Mile,Yes,"IJA, Denver",Kay Caskey,F,0,10:40.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1988,1988,3b 5km,Yes,"IJA, Denver",John Kilgust,M,0,19:34.3,?,http://www.juggling.org/orgs/ija/champs.txt
+1988,1988,3b 5km,Yes,"IJA, Denver",Albert Lucas,M,USA,20:39.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1988,1988,3b 5km,Yes,"IJA, Denver",Eric Promislow,M,0,23:21.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1988,1988,3b 5km,Yes,"IJA, Denver",Laurie Young,F,0,30:22.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1988,1988,3b Marathon,Yes,??,Albert Lucas,M,USA,29:04.0,?,
+1988,1988,3b Marathon,Yes,West Australian Marathon,Reg Bolton,M,GBR,45:50.0,?,https://www.heraldscotland.com/default_content/12429364.reg-bolton/  https://www.jugglingballs.com.au/15-famous-jugglers-from-australia-and-the-world/
+1987,1987,3b 100m,Yes,"IJA, Akron",Owen Morse,M,USA,00:12.1,?,http://www.juggling.org/orgs/ija/champs.txt
+1987,1987,3b 100m,Yes,"IJA, Akron",Tom Sparough,M,0,00:14.6,?,http://www.juggling.org/orgs/ija/champs.txt
+1987,1987,3b 100m,Yes,"IJA, Akron",Todd McLeish,M,0,00:14.9,?,http://www.juggling.org/orgs/ija/champs.txt
+1987,1987,3b Mile,Yes,"IJA, Akron",Todd McLeish,M,0,05:26.7,?,http://www.juggling.org/orgs/ija/champs.txt
+1987,1987,3b Mile,Yes,"IJA, Akron",Billy Gillen,M,USA,05:28.5,?,http://www.juggling.org/orgs/ija/champs.txt
+1987,1987,3b Mile,Yes,"IJA, Akron",Clarke McFarlane,M,0,05:34.3,?,http://www.juggling.org/orgs/ija/champs.txt
+1987,1987,3b 5km,Yes,"IJA, Akron",Billy Gillen,M,USA,19:52.4,?,http://www.juggling.org/orgs/ija/champs.txt
+1987,1987,3b 5km,Yes,"IJA, Akron",Clarke McFarlane,M,0,20:06.9,?,http://www.juggling.org/orgs/ija/champs.txt
+1986,1986,3b 100m,Yes,"IJA, San Jose",Owen Morse,M,USA,00:12.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1986,1986,3b 100m,Yes,"IJA, San Jose",Jerome Ellis,M,0,00:13.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1986,1986,3b 100m,Yes,"IJA, San Jose",Bill Giduz,M,USA,00:16.1,?,http://www.juggling.org/orgs/ija/champs.txt
+1986,1986,3b Mile,Yes,"IJA, San Jose",Kirk Swenson,M,USA,04:43.8,1,http://www.juggling.org/orgs/ija/champs.txt http://www.juggling.org/jw/86/3/joggling.html
+1986,1986,3b Mile,Yes,"IJA, San Jose",Marty Gardella,M,0,05:44.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1986,1986,3b Mile,Yes,"IJA, San Jose",Mickey Campaniello,M,0,05:48.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1986,1986,3b 5km,Yes,"IJA, San Jose",Kirk Swenson,M,USA,16:58.8,1,http://www.juggling.org/orgs/ija/champs.txt  http://www.juggling.org/jw/86/3/joggling.html
+1986,1986,3b 5km,Yes,"IJA, San Jose",Mickey Campaniello,M,0,19:20.8,?,http://www.juggling.org/orgs/ija/champs.txt
+1986,1986,3b 5km,Yes,"IJA, San Jose",Owen Morse,M,USA,20:27.4,?,http://www.juggling.org/orgs/ija/champs.txt
+1985,1985,3b 100m,Yes,"IJA, Atlanta",Bill Giduz,M,USA,00:15.1,?,http://www.juggling.org/orgs/ija/champs.txt
+1985,1985,3b 100m,Yes,"IJA, Atlanta",Lars Rohrback,M,0,00:17.5,?,http://www.juggling.org/orgs/ija/champs.txt
+1985,1985,3b 100m,Yes,"IJA, Atlanta",Michael Draney,M,0,00:20.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1985,1985,3b Mile,Yes,"IJA, Atlanta",Kirk Swenson,M,USA,04:47.5,?,http://www.juggling.org/orgs/ija/champs.txt
+1985,1985,3b Mile,Yes,"IJA, Atlanta",Banks Helfrich,M,0,05:06.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1985,1985,3b Mile,Yes,"IJA, Atlanta",Andrew Head,M,0,05:47.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1984,1984,3b 100m,Yes,"IJA, Las Vegas",Albert Lucas,M,USA,00:12.7,?,http://www.juggling.org/orgs/ija/champs.txt
+1984,1984,3b 100m,Yes,"IJA, Las Vegas",John Ellwanger,M,0,00:13.8,?,http://www.juggling.org/orgs/ija/champs.txt
+1984,1984,3b 100m,Yes,"IJA, Las Vegas",Ken Rabe,M,0,00:15.9,?,http://www.juggling.org/orgs/ija/champs.txt
+1984,1984,3b Mile,Yes,"IJA, Las Vegas",Kirk Swenson,M,USA,04:56.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1984,1984,3b Mile,Yes,"IJA, Las Vegas",Jim Piaskowy,M,0,05:06.9,?,http://www.juggling.org/orgs/ija/champs.txt
+1984,1984,3b Mile,Yes,"IJA, Las Vegas",John Ellwanger,M,0,05:23.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1983,1983,3b 100m,Yes,"IJA, Purchase, NY",Michel Lauzière,M,CAN,00:14.6,?,http://www.juggling.org/orgs/ija/champs.txt
+1983,1983,3b 100m,Yes,"IJA, Purchase, NY",Yvon Tourigny,M,0,00:14.8,?,http://www.juggling.org/orgs/ija/champs.txt
+1983,1983,3b 100m,Yes,"IJA, Purchase, NY",Matt Cantrell,M,0,00:15.6,?,http://www.juggling.org/orgs/ija/champs.txt
+1983,1983,3b Mile,Yes,"IJA, Purchase, NY",Michel Lauzière,M,CAN,05:25.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1983,1983,3b Mile,Yes,"IJA, Purchase, NY",Andrew Head,M,0,05:29.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1983,1983,3b Mile,Yes,"IJA, Purchase, NY",Paul Bernardo,M,0,05:38.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1983,1983,3b 5km,Yes,"IJA, Purchase, NY",Shidan Habib,M,0,19:35.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1983,1983,3b 5km,Yes,"IJA, Purchase, NY",Billy Gillen,M,USA,20:07.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1983,1983,3b 5km,Yes,"IJA, Purchase, NY",Michel Lauzière,M,CAN,20:09.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1983,1983,3c Marathon,No,Swindon Marathon,Colin Francome,M,GBR,26:00.0,?,"Phone call with Colin, August 2023"
+1982,1982,3b 100y,No,"IJA, Santa Barbara",Edward Sax,M,0,00:14.8,?,http://www.juggling.org/orgs/ija/champs.txt
+1982,1982,3b 100y,No,"IJA, Santa Barbara",Ken Rabe,M,0,00:15.1,?,http://www.juggling.org/orgs/ija/champs.txt
+1982,1982,3b 100y,No,"IJA, Santa Barbara",Matt Cantrell,M,0,00:17.8,?,http://www.juggling.org/orgs/ija/champs.txt
+1982,1982,3b Mile,Yes,"IJA, Santa Barbara",Sean McLoughlin,M,0,05:15.9,?,http://www.juggling.org/orgs/ija/champs.txt
+1982,1982,3b Mile,Yes,"IJA, Santa Barbara",Paul Williams,M,0,05:29.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1982,1982,3b Mile,Yes,"IJA, Santa Barbara",Bill Giduz,M,USA,05:36.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1982,1982,3b 5km,Yes,"IJA, Santa Barbara",Marty Gardella,M,0,18:48.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1982,1982,3b 5km,Yes,"IJA, Santa Barbara",Sean McLoughlin,M,0,19:00.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1982,1982,3b 5km,Yes,"IJA, Santa Barbara",David Marcias,M,0,19:51.0,?,http://www.juggling.org/orgs/ija/champs.txt
+1982,1982,3b Half Marathon,Yes,Montreal University Half Marathon,Michel Lauzière,M,CAN,19:00.0,?,Email exchange


### PR DESCRIPTION
Need to clean up the data a little, but poc works for sprints, relays etc.

Next steps will be to add in the EJC results from 2023, and the IJA 2011-present from Sterling